### PR TITLE
PY3 fixed installation without Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
     from setuptools import setup, Extension
     HAVE_CYTHON = True
 except ImportError as e:
-    warnings.warn(e.message)
+    warnings.warn(e.args[0])
     from setuptools import setup, Extension
     from setuptools.command.build_ext import build_ext
     HAVE_CYTHON = False


### PR DESCRIPTION
In Python 3 `pip install hdbscan` fails if Cython is not available:

```
pip install hdbscan
Collecting hdbscan
  Downloading hdbscan-0.8.2.tar.gz (3.6MB)
    100% |████████████████████████████████| 3.6MB 307kB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "/private/var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/pip-build-t3mz0asu/hdbscan/setup.py", line 4, in <module>
        from Cython.Distutils import build_ext
    ImportError: No module named 'Cython'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/pip-build-t3mz0asu/hdbscan/setup.py", line 8, in <module>
        warnings.warn(e.message)
    AttributeError: 'ImportError' object has no attribute 'message'
```