### PR TITLE
Fix spelling mistakes in advanced_hdbscan.rst & how_hdbscan_works.rst

### DIFF
--- a/docs/advanced_hdbscan.rst
+++ b/docs/advanced_hdbscan.rst
@@ -216,7 +216,7 @@ the ``child_size`` provides the number of points in the child cluster.
 As you can see the start of the dataframe has singleton points falling
 out of the root cluster, with each ``child_size`` equal to 1.
 
-If you want just he clusters, rather than all the individual points
+If you want just the clusters, rather than all the individual points
 as well, simply select the rows of the dataframe with ``child_size``
 greater than 1.
 

--- a/docs/how_hdbscan_works.rst
+++ b/docs/how_hdbscan_works.rst
@@ -159,7 +159,7 @@ again.
 .. image:: images/distance3.svg
 
 Now if we want to know the mutual reachability distance between the
-blue and green points we can start by drawing in and arrow giving the
+blue and green points we can start by drawing in an arrow giving the
 distance between green and blue:
 
 .. image:: images/distance4.svg


### PR DESCRIPTION
Simple fixes to spelling mistakes. 
- advanced_hdbscan.rst : 'he' to 'the, line 219
- how_hdbscan_works.rst : 'and' to 'an', line 162 