### PR TITLE
switch order of arguments in networkx::set_node_attributes

### DIFF
--- a/hdbscan/plots.py
+++ b/hdbscan/plots.py
@@ -449,7 +449,7 @@ class CondensedTree(object):
         for row in self._raw_tree:
             result.add_edge(row['parent'], row['child'], weight=row['lambda_val'])
 
-        set_node_attributes(result, 'size', dict(self._raw_tree[['child', 'child_size']]))
+        set_node_attributes(result, dict(self._raw_tree[['child', 'child_size']]), 'size')
 
         return result
 
@@ -655,7 +655,7 @@ class SingleLinkageTree(object):
             result.add_edge(parent, row[1], weight=row[2])
 
         size_dict = {parent: row[3] for parent, row in enumerate(self._linkage, num_points)}
-        set_node_attributes(result, 'size', size_dict)
+        set_node_attributes(result, size_dict, 'size')
 
         return result
 
@@ -824,6 +824,6 @@ class MinimumSpanningTree(object):
             result.add_edge(row[0], row[1], weight=row[2])
 
         data_dict = {index: tuple(row) for index, row in enumerate(self._data)}
-        set_node_attributes(result, 'data', data_dict)
+        set_node_attributes(result, data_dict, 'data')
 
         return result


### PR DESCRIPTION
It looks like the order of arguments changes between [1.9](https://networkx.github.io/documentation/networkx-1.9/reference/generated/networkx.classes.function.set_node_attributes.html) than [2.0](https://networkx.github.io/documentation/networkx-2.0/reference/generated/networkx.classes.function.set_node_attributes.html).

Since the networkx version 1.9 isn't specified in requirements.txt, I think it should reflect the newest version.