### PR TITLE
Does not need numpy installed before installing hdbscan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,26 +10,34 @@ except ImportError as e:
     from setuptools.command.build_ext import build_ext
     HAVE_CYTHON = False
 
-import numpy
+
+class CustomBuildExtCommand(build_ext):
+    """build_ext command for use when numpy headers are needed."""
+    def run(self):
+
+        # Import numpy here, only when headers are needed
+        import numpy
+
+        # Add numpy headers to include_dirs
+        self.include_dirs.append(numpy.get_include())
+
+        # Call original build_ext command
+        build_ext.run(self)
+
 
 _hdbscan_tree = Extension('hdbscan._hdbscan_tree',
-                          sources=['hdbscan/_hdbscan_tree.pyx'],
-                          include_dirs=[numpy.get_include()])
+                          sources=['hdbscan/_hdbscan_tree.pyx'])
 _hdbscan_linkage = Extension('hdbscan._hdbscan_linkage',
-                             sources=['hdbscan/_hdbscan_linkage.pyx'],
-                             include_dirs=['hdbscan', numpy.get_include()])
+                             sources=['hdbscan/_hdbscan_linkage.pyx'])
 _hdbscan_boruvka = Extension('hdbscan._hdbscan_boruvka',
-                             sources=['hdbscan/_hdbscan_boruvka.pyx'],
-                             include_dirs=['hdbscan', numpy.get_include()])
+                             sources=['hdbscan/_hdbscan_boruvka.pyx'])
 _hdbscan_reachability = Extension('hdbscan._hdbscan_reachability',
-                                  sources=['hdbscan/_hdbscan_reachability.pyx'],
-                                  include_dirs=[numpy.get_include()])
+                                  sources=['hdbscan/_hdbscan_reachability.pyx'])
 _prediction_utils = Extension('hdbscan._prediction_utils',
-                              sources=['hdbscan/_prediction_utils.pyx'],
-                              include_dirs=[numpy.get_include()])
+                              sources=['hdbscan/_prediction_utils.pyx'])
 dist_metrics = Extension('hdbscan.dist_metrics',
-                         sources=['hdbscan/dist_metrics.pyx'],
-                         include_dirs=[numpy.get_include()])
+                         sources=['hdbscan/dist_metrics.pyx'])
+
 
 def readme():
     with open('README.rst') as readme_file:
@@ -62,7 +70,8 @@ configuration = {
     'maintainer_email' : 'leland.mcinnes@gmail.com',
     'license' : 'BSD',
     'packages' : ['hdbscan'],
-    'install_requires' : ['scikit-learn>=0.16',
+    'install_requires' : ['numpy',
+                          'scikit-learn>=0.16',
                           'cython >= 0.17'],
     'ext_modules' : [_hdbscan_tree,
                      _hdbscan_linkage,
@@ -70,7 +79,7 @@ configuration = {
                      _hdbscan_reachability,
                      _prediction_utils,
                      dist_metrics],
-    'cmdclass' : {'build_ext' : build_ext},
+    'cmdclass' : {'build_ext' : CustomBuildExtCommand},
     'test_suite' : 'nose.collector',
     'tests_require' : ['nose'],
     'data_files' : ('hdbscan/dist_metrics.pxd',)
@@ -83,7 +92,6 @@ if not HAVE_CYTHON:
     _hdbscan_reachability.sources[0] = 'hdbscan/_hdbscan_reachability.c'
     _prediction_utils.sources[0] = 'hdbscan/_prediction_utils.c'
     dist_metrics.sources[0] = 'hdbscan/dist_metrics.c'
-    configuration['install_requires'] = ['scikit-learn>=0.16']
+    configuration['install_requires'] = ['numpy', 'scikit-learn>=0.16']
 
 setup(**configuration)
- 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ except ImportError as e:
 
 class CustomBuildExtCommand(build_ext):
     """build_ext command for use when numpy headers are needed."""
+
     def run(self):
 
         # Import numpy here, only when headers are needed
@@ -43,12 +44,13 @@ def readme():
     with open('README.rst') as readme_file:
         return readme_file.read()
 
+
 configuration = {
-    'name' : 'hdbscan',
-    'version' : '0.8.11',
-    'description' : 'Clustering based on density with variable density clusters',
-    'long_description' : readme(),
-    'classifiers' : [
+    'name': 'hdbscan',
+    'version': '0.8.11',
+    'description': 'Clustering based on density with variable density clusters',
+    'long_description': readme(),
+    'classifiers': [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',
@@ -64,26 +66,26 @@ configuration = {
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
     ],
-    'keywords' : 'cluster clustering density hierarchical',
-    'url' : 'http://github.com/scikit-learn-contrib/hdbscan',
-    'maintainer' : 'Leland McInnes',
-    'maintainer_email' : 'leland.mcinnes@gmail.com',
-    'license' : 'BSD',
-    'packages' : ['hdbscan'],
-    'install_requires' : ['numpy',
-                          'scikit-learn>=0.16',
-                          'cython >= 0.17'],
-    'ext_modules' : [_hdbscan_tree,
-                     _hdbscan_linkage,
-                     _hdbscan_boruvka,
-                     _hdbscan_reachability,
-                     _prediction_utils,
-                     dist_metrics],
-    'cmdclass' : {'build_ext' : CustomBuildExtCommand},
-    'test_suite' : 'nose.collector',
-    'tests_require' : ['nose'],
-    'data_files' : ('hdbscan/dist_metrics.pxd',)
-    }
+    'keywords': 'cluster clustering density hierarchical',
+    'url': 'http://github.com/scikit-learn-contrib/hdbscan',
+    'maintainer': 'Leland McInnes',
+    'maintainer_email': 'leland.mcinnes@gmail.com',
+    'license': 'BSD',
+    'packages': ['hdbscan'],
+    'install_requires': ['numpy',
+                         'scikit-learn>=0.16',
+                         'cython >= 0.17'],
+    'ext_modules': [_hdbscan_tree,
+                    _hdbscan_linkage,
+                    _hdbscan_boruvka,
+                    _hdbscan_reachability,
+                    _prediction_utils,
+                    dist_metrics],
+    'cmdclass': {'build_ext': CustomBuildExtCommand},
+    'test_suite': 'nose.collector',
+    'tests_require': ['nose'],
+    'data_files': ('hdbscan/dist_metrics.pxd',)
+}
 
 if not HAVE_CYTHON:
     _hdbscan_tree.sources[0] = 'hdbscan/_hdbscan_tree.c'


### PR DESCRIPTION
If you ran `pip install hdbscan` in an empty virtual environment, you would get in error when setup.py tried to import numpy.

Adding this custom wrapper around build_ext will make it so numpy is installed first. Then the installation process can use it for the rest of the installation of hdbscan.

This method is credit to R_Beagrie's SO answer: https://stackoverflow.com/a/42163080