### PR TITLE
[WIP] Sample weighting feature implementation

### DIFF
--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -855,16 +855,15 @@ cdef class KDTreeBoruvkaAlgorithm (object):
 
         return 0
 
-    def spanning_tree(self):
+    cpdef spanning_tree(self):
         """Compute the minimum spanning tree of the data held by
         the tree passed in at construction"""
 
-        # cdef np.intp_t num_components
-        # cdef np.intp_t num_nodes
+        cdef np.intp_t num_components
+        cdef np.intp_t num_nodes
 
         num_components = self.tree.data.shape[0]
         num_nodes = self.tree.node_data.shape[0]
-        iteration = 0
         while num_components > 1:
             self.dual_tree_traversal(0, 0)
             num_components = self.update_components()
@@ -1055,14 +1054,14 @@ cdef class BallTreeBoruvkaAlgorithm (object):
                 delayed(_core_dist_query,
                         check_pickle=False)
                 (self.core_dist_tree, points,
-                 self.min_samples)
+                 self.min_samples + 1)
                 for points in datasets)
             knn_dist = np.vstack([x[0] for x in knn_data])
             knn_indices = np.vstack([x[1] for x in knn_data])
         else:
             knn_dist, knn_indices = self.core_dist_tree.query(
                 self.tree.data,
-                k=self.min_samples,
+                k=self.min_samples + 1,
                 dualtree=True,
                 breadth_first=True)
 
@@ -1098,7 +1097,7 @@ cdef class BallTreeBoruvkaAlgorithm (object):
         # issues, but we'll get quite a few, and they are the hard ones to get,
         # so fill in any we ca and then run update components.
         for n in range(self.num_points):
-            for i in range(self.min_samples - 1, 0):
+            for i in range(1, self.min_samples + 1):
                 m = knn_indices[n, i]
                 if self.core_distance[m] <= self.core_distance[n]:
                     self.candidate_point[n] = n

--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -416,7 +416,7 @@ cdef class KDTreeBoruvkaAlgorithm (object):
                                           3*(self.num_points//4)]),
                 np.asarray(self.tree.data[3*(self.num_points//4):
                                           self.num_points])
-                        ]
+            ]
 
             knn_data = Parallel(n_jobs=self.n_jobs)(
                 delayed(_core_dist_query,
@@ -1041,14 +1041,15 @@ cdef class BallTreeBoruvkaAlgorithm (object):
         cdef np.ndarray[np.intp_t, ndim=1] idx_row
 
         if self.tree.data.shape[0] > 16384 and self.n_jobs > 1:
-            datasets = [np.asarray(self.tree.data[0:self.num_points//4]),
-                        np.asarray(self.tree.data[self.num_points//4:
-                                                  self.num_points//2]),
-                        np.asarray(self.tree.data[self.num_points//2:
-                                                  3*(self.num_points//4)]),
-                        np.asarray(self.tree.data[3*(self.num_points//4):
-                                                  self.num_points])
-                        ]
+            datasets = [
+                np.asarray(self.tree.data[0:self.num_points//4]),
+                np.asarray(self.tree.data[self.num_points//4:
+                                          self.num_points//2]),
+                np.asarray(self.tree.data[self.num_points//2:
+                                          3*(self.num_points//4)]),
+                np.asarray(self.tree.data[3*(self.num_points//4):
+                                          self.num_points])
+            ]
 
             knn_data = Parallel(n_jobs=self.n_jobs)(
                 delayed(_core_dist_query,

--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -433,28 +433,34 @@ cdef class KDTreeBoruvkaAlgorithm (object):
                 dualtree=True,
                 breadth_first=True)
 
-        if self.sample_weights is not None:
-            # Use cumulative sum of weights to find the weighted nearest
-            # neighbour satisfying min_samples.
-            # TODO: This part might have the highest impact on performance.
-            self.core_distance_arr = np.empty(
-                shape=(self.num_points), dtype='float64')
-            for idx in range(self.num_points):
-                idx_row = knn_indices[idx, :].reshape(1, -1).flatten()
-                cs = np.cumsum(self.sample_weights[idx_row])
-                if cs[self.min_samples] < self.min_samples:
-                    # If zero weights don't allow for a big enough cluster
-                    # return maximal possible core distance to "ignore"
-                    # the point under consideration.
-                    # TODO: INF would be more apporpriate, but is causing errors
-                    # on later stages with spanning_tree() (hdbscan_.py 244)
-                    self.core_distance_arr[idx] = INT_MAX
-                else:
-                    # Based on https://stackoverflow.com/a/25032853/4272484
-                    weighted_idx = np.searchsorted(cs, self.min_samples)
-                    self.core_distance_arr[idx] = knn_dist[idx, weighted_idx]
-        else:
-            self.core_distance_arr = knn_dist[:, self.min_samples].copy()
+        # if self.sample_weights is not None:
+        #     # Use cumulative sum of weights to find the weighted nearest
+        #     # neighbour satisfying min_samples.
+        #     # TODO: This part might have the highest impact on performance.
+        #     self.core_distance_arr = np.empty(
+        #         shape=(self.num_points), dtype='float64')
+        #     for idx in range(self.num_points):
+        #         idx_row = knn_indices[idx, :].reshape(1, -1).flatten()
+        #         cs = np.cumsum(self.sample_weights[idx_row])
+        #         if cs[self.min_samples] < self.min_samples:
+        #             # If zero weights don't allow for a big enough cluster
+        #             # return maximal possible core distance to "ignore"
+        #             # the point under consideration.
+        #             # TODO: INF would be more apporpriate, but is causing errors
+        #             # on later stages with spanning_tree() (hdbscan_.py 244)
+        #             ###
+        #             weighted_idx = np.searchsorted(cs, self.min_samples)
+        #             self.core_distance_arr[idx] = knn_dist[idx, weighted_idx]
+        #             ###
+        #             # self.core_distance_arr[idx] = knn_dist[idx, self.min_samples]
+        #             # self.core_distance_arr[idx] = self.min_samples
+        #             # self.core_distance_arr[idx] = INT_MAX
+        #         else:
+        #             # Based on https://stackoverflow.com/a/25032853/4272484
+        #             weighted_idx = np.searchsorted(cs, self.min_samples)
+        #             self.core_distance_arr[idx] = knn_dist[idx, weighted_idx]
+        # else:
+        self.core_distance_arr = knn_dist[:, self.min_samples].copy()
 
         self.core_distance = (<np.double_t[:self.num_points:1]> (
             <np.double_t *> self.core_distance_arr.data))
@@ -1065,28 +1071,34 @@ cdef class BallTreeBoruvkaAlgorithm (object):
                 dualtree=True,
                 breadth_first=True)
 
-        if self.sample_weights is not None:
-            # Use cumulative sum of weights to find the weighted nearest
-            # neighbour satisfying min_samples.
-            # TODO: This part might have the highest impact on performance.
-            self.core_distance_arr = np.empty(
-                shape=(self.num_points), dtype='float64')
-            for idx in range(self.num_points):
-                idx_row = knn_indices[idx, :].reshape(1, -1).flatten()
-                cs = np.cumsum(self.sample_weights[idx_row])
-                if cs[self.min_samples] < self.min_samples:
-                    # If zero weights don't allow for a big enough cluster
-                    # return maximal possible core distance to "ignore"
-                    # the point under consideration.
-                    # TODO: INF would be more apporpriate, but is causing errors
-                    # on later stages with spanning_tree() (hdbscan_.py 244)
-                    self.core_distance_arr[idx] = INT_MAX
-                else:
-                    # Based on https://stackoverflow.com/a/25032853/4272484
-                    weighted_idx = np.searchsorted(cs, self.min_samples)
-                    self.core_distance_arr[idx] = knn_dist[idx, weighted_idx]
-        else:
-            self.core_distance_arr = knn_dist[:, self.min_samples].copy()
+        # if self.sample_weights is not None:
+        #     # Use cumulative sum of weights to find the weighted nearest
+        #     # neighbour satisfying min_samples.
+        #     # TODO: This part might have the highest impact on performance.
+        #     self.core_distance_arr = np.empty(
+        #         shape=(self.num_points), dtype='float64')
+        #     for idx in range(self.num_points):
+        #         idx_row = knn_indices[idx, :].reshape(1, -1).flatten()
+        #         cs = np.cumsum(self.sample_weights[idx_row])
+        #         if cs[self.min_samples] < self.min_samples:
+        #             # If zero weights don't allow for a big enough cluster
+        #             # return maximal possible core distance to "ignore"
+        #             # the point under consideration.
+        #             # TODO: INF would be more apporpriate, but is causing errors
+        #             # on later stages with spanning_tree() (hdbscan_.py 244)
+        #             ###
+        #             # weighted_idx = np.searchsorted(cs, self.min_samples)
+        #             # self.core_distance_arr[idx] = knn_dist[idx, weighted_idx]
+        #             ###
+        #             # self.core_distance_arr[idx] = knn_dist[idx, self.min_samples]
+        #             # self.core_distance_arr[idx] = self.min_samples
+        #             self.core_distance_arr[idx] = INT_MAX
+        #         else:
+        #             # Based on https://stackoverflow.com/a/25032853/4272484
+        #             weighted_idx = np.searchsorted(cs, self.min_samples)
+        #             self.core_distance_arr[idx] = knn_dist[idx, weighted_idx]
+        # else:
+        self.core_distance_arr = knn_dist[:, self.min_samples].copy()
 
         self.core_distance = (<np.double_t[:self.num_points:1]> (
             <np.double_t *> self.core_distance_arr.data))

--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -400,6 +400,10 @@ cdef class KDTreeBoruvkaAlgorithm (object):
         cdef np.ndarray[np.double_t, ndim=2] knn_dist
         cdef np.ndarray[np.intp_t, ndim=2] knn_indices
 
+        cdef np.intp_t idx
+        cdef np.intp_t weighted_idx
+        cdef np.ndarray[np.intp_t, ndim=1] idx_row
+
         # A shortcut: if we have a lot of points then we can split the points
         # into four piles and query them in parallel. On multicore systems
         # (most systems) this amounts to a 2x-3x wall clock improvement.
@@ -1031,6 +1035,10 @@ cdef class BallTreeBoruvkaAlgorithm (object):
 
         cdef np.ndarray[np.double_t, ndim=2] knn_dist
         cdef np.ndarray[np.intp_t, ndim=2] knn_indices
+
+        cdef np.intp_t idx
+        cdef np.intp_t weighted_idx
+        cdef np.ndarray[np.intp_t, ndim=1] idx_row
 
         if self.tree.data.shape[0] > 16384 and self.n_jobs > 1:
             datasets = [np.asarray(self.tree.data[0:self.num_points//4]),

--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -73,7 +73,7 @@ cimport dist_metrics as dist_metrics
 from sklearn.externals.joblib import Parallel, delayed
 
 cdef np.double_t INF = np.inf
-cdef np.intp_t INT_MAX = sys.maxint
+# cdef np.intp_t INT_MAX = sys.maxint
 
 
 # Define the NodeData struct used in sklearn trees for faster

--- a/hdbscan/_hdbscan_linkage.pyx
+++ b/hdbscan/_hdbscan_linkage.pyx
@@ -194,7 +194,8 @@ cdef class UnionFind (object):
         return n
 
 
-cpdef np.ndarray[np.double_t, ndim=2] label(np.ndarray[np.double_t, ndim=2] L):
+cpdef np.ndarray[np.double_t, ndim=2] label(
+        np.ndarray[np.double_t, ndim=2] L, sample_weights=None):
 
     cdef np.ndarray[np.double_t, ndim=2] result_arr
     cdef np.double_t[:, ::1] result
@@ -206,7 +207,7 @@ cpdef np.ndarray[np.double_t, ndim=2] label(np.ndarray[np.double_t, ndim=2] L):
     result = (<np.double_t[:L.shape[0], :4:1]> (
         <np.double_t *> result_arr.data))
     N = L.shape[0] + 1
-    U = UnionFind(N)
+    U = UnionFind(N, sample_weights)
 
     for index in range(L.shape[0]):
 
@@ -226,7 +227,8 @@ cpdef np.ndarray[np.double_t, ndim=2] label(np.ndarray[np.double_t, ndim=2] L):
     return result_arr
 
 
-cpdef np.ndarray[np.double_t, ndim=2] single_linkage(distance_matrix):
+cpdef np.ndarray[np.double_t, ndim=2] single_linkage(
+        distance_matrix, sample_weights=None):
 
     cdef np.ndarray[np.double_t, ndim=2] hierarchy
     cdef np.ndarray[np.double_t, ndim=2] for_labelling
@@ -234,4 +236,4 @@ cpdef np.ndarray[np.double_t, ndim=2] single_linkage(distance_matrix):
     hierarchy = mst_linkage_core(distance_matrix)
     for_labelling = hierarchy[np.argsort(hierarchy.T[2]), :]
 
-    return label(for_labelling)
+    return label(for_labelling, sample_weights)

--- a/hdbscan/_hdbscan_linkage.pyx
+++ b/hdbscan/_hdbscan_linkage.pyx
@@ -166,11 +166,16 @@ cdef class UnionFind (object):
     cdef np.intp_t *parent
     cdef np.intp_t *size
 
-    def __init__(self, N):
+    def __init__(self, N, sample_weights):
         self.parent_arr = -1 * np.ones(2 * N - 1, dtype=np.intp, order='C')
         self.next_label = N
-        self.size_arr = np.hstack((np.ones(N, dtype=np.intp),
-                                   np.zeros(N-1, dtype=np.intp)))
+        # Initialise size array with sample_weights if given
+        if sample_weights is not None:
+            self.size_arr = np.hstack((sample_weights,
+                                       np.zeros(N-1, dtype=np.intp)))
+        else:
+            self.size_arr = np.hstack((np.ones(N, dtype=np.intp),
+                                       np.zeros(N-1, dtype=np.intp)))
         self.parent = (<np.intp_t *> self.parent_arr.data)
         self.size = (<np.intp_t *> self.size_arr.data)
 

--- a/hdbscan/_prediction_utils.pyx
+++ b/hdbscan/_prediction_utils.pyx
@@ -324,7 +324,8 @@ cpdef all_points_prob_in_some_cluster(
         np.ndarray[np.intp_t, ndim=1] clusters,
         np.ndarray tree,
         dict max_lambda_dict,
-        np.ndarray cluster_tree):
+        np.ndarray cluster_tree,
+        inf = float('inf')):
 
     cdef np.ndarray[np.float64_t, ndim=1] heights
     cdef np.intp_t num_points = tree['parent'].min()
@@ -351,7 +352,9 @@ cpdef all_points_prob_in_some_cluster(
                                clusters, cluster_tree)
         max_lambda = max(max_lambda_dict[clusters[heights.argmax()]],
                          point_lambda)
-        result[point] = (heights.max() / max_lambda)
+        if max_lambda == inf:
+            result[point] = 1
+        else:
+            result[point] = (heights.max() / max_lambda)
 
     return result
-

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -227,6 +227,8 @@ def _hdbscan_boruvka_kdtree(X, sample_weights=None, min_samples=5, alpha=1.0,
     if core_dist_n_jobs < 1:
         core_dist_n_jobs = max(cpu_count() + 1 + core_dist_n_jobs, 1)
 
+    # TODO: What about np.float32 if someone doesn't need 64 bits of precision?
+    # Shouldn't np.issubdtype(X.dtype, np.float) be used?
     if X.dtype != np.float64:
         X = X.astype(np.float64)
 
@@ -829,6 +831,7 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
 
         return self
 
+    # TODO: Weighting?
     def fit_predict(self, X, y=None):
         """Performs clustering on X and returns cluster labels.
 

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -105,8 +105,7 @@ def _hdbscan_generic(X, sample_weights=None, min_samples=5, alpha=1.0,
         result_min_span_tree = None
 
     # Sort edges of the min_spanning_tree by weight
-    min_spanning_tree = min_spanning_tree[np.argsort(min_spanning_tree.T[2]),
-                        :]
+    min_spanning_tree = min_spanning_tree[np.argsort(min_spanning_tree.T[2]), :]
 
     # Convert edge list into standard hierarchical clustering format
     single_linkage_tree = label(min_spanning_tree, sample_weights)
@@ -143,8 +142,7 @@ def _hdbscan_sparse_distance_matrix(X, sample_weights=None, min_samples=5, alpha
     min_spanning_tree = np.vstack(nonzeros + (nonzero_vals,)).T
 
     # Sort edges of the min_spanning_tree by weight
-    min_spanning_tree = min_spanning_tree[np.argsort(min_spanning_tree.T[2]),
-                        :][0]
+    min_spanning_tree = min_spanning_tree[np.argsort(min_spanning_tree.T[2]), :][0]
 
     # Convert edge list into standard hierarchical clustering format
     single_linkage_tree = label(min_spanning_tree, sample_weights)
@@ -211,8 +209,7 @@ def _hdbscan_prims_balltree(X, sample_weights=None, min_samples=5, alpha=1.0,
     min_spanning_tree = mst_linkage_core_vector(X, core_distances, dist_metric,
                                                 alpha)
     # Sort edges of the min_spanning_tree by weight
-    min_spanning_tree = min_spanning_tree[np.argsort(min_spanning_tree.T[2]),
-                        :]
+    min_spanning_tree = min_spanning_tree[np.argsort(min_spanning_tree.T[2]), :]
     # Convert edge list into standard hierarchical clustering format
     single_linkage_tree = label(min_spanning_tree, sample_weights)
 
@@ -274,8 +271,8 @@ def _hdbscan_boruvka_balltree(X, sample_weights=None, min_samples=5, alpha=1.0,
                                    n_jobs=core_dist_n_jobs, **kwargs)
     min_spanning_tree = alg.spanning_tree()
     # Sort edges of the min_spanning_tree by weight
-    min_spanning_tree = min_spanning_tree[np.argsort(min_spanning_tree.T[2]),
-                        :]
+    row_order = np.argsort(min_spanning_tree.T[2])
+    min_spanning_tree = min_spanning_tree[row_order, :]
     # Convert edge list into standard hierarchical clustering format
     single_linkage_tree = label(min_spanning_tree, sample_weights)
 
@@ -750,7 +747,7 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
 
     """
 
-    def __init__(self, min_cluster_size=5, min_samples=None,
+    def __init__(self, min_samples=None, min_cluster_size=5,
                  metric='euclidean', alpha=1.0, p=None,
                  algorithm='best', leaf_size=40,
                  memory=Memory(cachedir=None, verbose=0),
@@ -761,8 +758,8 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
                  allow_single_cluster=False,
                  prediction_data=False,
                  match_reference_implementation=False, **kwargs):
-        self.min_cluster_size = min_cluster_size
         self.min_samples = min_samples
+        self.min_cluster_size = min_cluster_size
         self.alpha = alpha
 
         self.metric = metric

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -13,7 +13,7 @@ from sklearn.neighbors import KDTree, BallTree
 from sklearn.externals.joblib import Memory
 from sklearn.externals import six
 from warnings import warn
-from sklearn.utils import check_array
+from sklearn.utils import check_array, check_consistent_length
 from sklearn.externals.joblib.parallel import cpu_count
 
 from scipy.sparse import csgraph
@@ -799,6 +799,14 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
             Returns self
         """
         X = check_array(X, accept_sparse='csr')
+        if sample_weights is not None:
+            sample_weights = np.asarray(sample_weights)
+            check_consistent_length(X, sample_weights)
+            if ~np.issubdtype(sample_weights.dtype, np.integer):
+                # TODO: Only integer weights implemented so far.
+                # Should a warning be raised?
+                sample_weights = sample_weights.astype(np.int64)
+
         if self.metric != 'precomputed':
             self._raw_data = X
 

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -866,7 +866,7 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
             else:
                 warn('Metric {} not supported for prediction data!'.format(self.metric))
                 return
-                
+
             self._prediction_data = PredictionData(
                 self._raw_data, self.condensed_tree_, min_samples,
                 tree_type=tree_type, metric=self.metric,

--- a/hdbscan/prediction.py
+++ b/hdbscan/prediction.py
@@ -521,6 +521,7 @@ def all_points_membership_vectors(clusterer):
     :py:func:`hdbscan.predict.predict`
     :py:func:`hdbscan.predict.all_points_membership_vectors`
     """
+
     clusters = np.array(list(clusterer.condensed_tree_._select_clusters()
                              )).astype(np.intp)
     all_points = clusterer.prediction_data_.raw_data

--- a/hdbscan/robust_single_linkage_.py
+++ b/hdbscan/robust_single_linkage_.py
@@ -103,7 +103,7 @@ def _rsl_boruvka_kdtree(X, k=5, alpha=1.0,
     min_samples = min(dim - 1, k)
 
     tree = KDTree(X, metric=metric, leaf_size=leaf_size, **kwargs)
-    alg = KDTreeBoruvkaAlgorithm(tree, min_samples, metric=metric,
+    alg = KDTreeBoruvkaAlgorithm(tree, min_samples=min_samples, metric=metric,
                                  alpha=alpha, leaf_size=leaf_size, **kwargs)
     min_spanning_tree = alg.spanning_tree()
 
@@ -124,7 +124,7 @@ def _rsl_boruvka_balltree(X, k=5, alpha=1.0,
     min_samples = min(dim - 1, k)
 
     tree = BallTree(X, metric=metric, leaf_size=leaf_size, **kwargs)
-    alg = BallTreeBoruvkaAlgorithm(tree, min_samples, metric=metric,
+    alg = BallTreeBoruvkaAlgorithm(tree, min_samples=min_samples, metric=metric,
                                    alpha=alpha, leaf_size=leaf_size, **kwargs)
     min_spanning_tree = alg.spanning_tree()
 


### PR DESCRIPTION
As discussed, a sample weighting implementation PR. "Tested" with all 6 algorithm options, but lacking any formal tests (on a roadmap...).

Weights are basically used as starting sizes for tree creation in `_hdbscan_linkage.pyx`, the rest (e.g. core distance calculation) is (hopefully) untouched. As you can see in the commit log, initially weighs were passed down to the core dist calculation, but this does not seem to be a good idea (it was causing all 0 weights points to be virtually "excluded" from clustering, we believe this approach is much more appropriate).

A quick demonstration (please uncomment plots if feeling adventurous):

```
'''
Example of weighted HDBSCAN.
'''

import numpy as np
import matplotlib.pyplot as plt
import seaborn as sns

from sklearn.datasets import make_blobs
from sklearn.utils import shuffle
from sklearn.preprocessing import StandardScaler

from hdbscan import HDBSCAN

plot_kwds = {'linewidths':0}
palette = sns.color_palette("hls", 20)


# Generate data
np.random.seed(1)
X, y = make_blobs(n_samples=400, cluster_std=3, shuffle=True, random_state=10)
X, y = shuffle(X, y, random_state=7)
X = StandardScaler().fit_transform(X)

sample_weights = np.floor(np.random.standard_gamma(shape=0.5, size=len(X))) * 4

sizes = ((sample_weights+1)*10).astype(int)
alphas = np.fromiter((0.5 if s < 1 else 0.75 for s in sample_weights), np.float, 400).reshape(-1,1)

algorithm = 'best'
# algorithm = 'generic'
# algorithm = 'prims_kdtree'
# algorithm = 'prims_balltree'
# algorithm = 'boruvka_kdtree'
# algorithm = 'boruvka_balltree'

min_cluster_size, min_samples = 8, 1


# (Unweighted) HDBSCAN
np.random.seed(1)
hdb_unweighted = HDBSCAN(
    min_cluster_size=min_cluster_size, min_samples=min_samples, gen_min_span_tree=True, allow_single_cluster=False,
    algorithm=algorithm, prediction_data=True)
hdb_unweighted.fit(X)

cluster_colours = np.asarray([palette[lab] if lab >= 0 else (0.0, 0.0, 0.0) for lab in hdb_unweighted.labels_])
cluster_colours = np.hstack([cluster_colours, alphas])

fig = plt.figure()
plt.scatter(X.T[0], X.T[1], s=sizes, c=cluster_colours, **plot_kwds)
fig.suptitle('Unweighted HDBSCAN'); plt.show()

## Lots of plots, all working!
fig = plt.figure()
hdb_unweighted.minimum_spanning_tree_.plot(edge_cmap='viridis', edge_alpha=0.5, node_size=40, edge_linewidth=2)
fig.suptitle('Unweighted HDBSCAN minimum spanning tree'); plt.show()
fig = plt.figure()
hdb_unweighted.single_linkage_tree_.plot(cmap='viridis', colorbar=True)
fig.suptitle('Unweighted HDBSCAN single linkage tree'); plt.show()
fig = plt.figure()
hdb_unweighted.condensed_tree_.plot(select_clusters=True, selection_palette=palette, log_size=True)
fig.suptitle('Unweighted HDBSCAN condensed tree plot'); plt.show()


# (Weighted) HDBSCAN
np.random.seed(1)
hdb_weighted = HDBSCAN(
    min_cluster_size=min_cluster_size, min_samples=min_samples, gen_min_span_tree=True, allow_single_cluster=False,
    algorithm=algorithm, prediction_data=True)
hdb_weighted.fit(X, sample_weights=sample_weights)

cluster_colours = np.asarray([palette[lab] if lab >= 0 else (0.0, 0.0, 0.0) for lab in hdb_weighted.labels_])
cluster_colours = np.hstack([cluster_colours, alphas])

fig = plt.figure()
plt.scatter(X.T[0], X.T[1], s=sizes, c=cluster_colours, **plot_kwds)
fig.suptitle('Weighted HDBSCAN'); plt.show()

## Lots of plots, all working (except one or two warnings...)!
fig = plt.figure()
hdb_weighted.minimum_spanning_tree_.plot(edge_cmap='viridis', edge_alpha=0.5, node_size=40, edge_linewidth=2)
fig.suptitle('Weighted HDBSCAN minimum spanning tree'); plt.show()
# single_linkage_tree throws "plots.py:563: RuntimeWarning: divide by zero encountered in log2" but works.
fig = plt.figure()
hdb_weighted.single_linkage_tree_.plot(cmap='viridis', colorbar=True)
fig.suptitle('Weighted HDBSCAN single linkage tree'); plt.show()
fig = plt.figure()
hdb_weighted.condensed_tree_.plot(select_clusters=True, selection_palette=palette, log_size=True)
fig.suptitle('Weighted HDBSCAN condensed tree plot'); plt.show()

## Check weights by cluster:
unweighted_weights = np.asarray([[lab, sum(sample_weights[hdb_unweighted.labels_ == lab])] for lab in set(hdb_unweighted.labels_)])
weighted_weights = np.asarray([[lab, sum(sample_weights[hdb_weighted.labels_ == lab])] for lab in set(hdb_weighted.labels_)])
print(unweighted_weights)
print(weighted_weights)

```

We are VERY open to discussion.