### PR TITLE
allow np.inf for missing values in case of precomputed metric

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -829,7 +829,12 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
         if self.metric != 'precomputed':
             X = check_array(X, accept_sparse='csr')
             self._raw_data = X
+        elif issparse(X):
+            # Handle sparse precomputed distance matrices separately
+            X = check_array(X, accept_sparse='csr')
         else:
+            # Only non-sparse, precomputed distance matrices are allowed
+            #   to have numpy.inf values indicating missing distances
             check_precomputed_distance_matrix(X)
 
         kwargs = self.get_params()


### PR DESCRIPTION
This is a first attempt to allow entries in a precomputed distance matrix to be undefined by setting them to `numpy.inf` (#187). The only necessary change seemed to be handling the input validation separately for the case `metric == 'precomputed'`and using `numpy.inf` instead of `numpy.nan` to not mess with the sorting, comparing and dividing in down-stream computations.  
I have attempted a workaround for the input validation by adding `check_precomputed_distance_matrix(X)` that executes the same checks as `check_matrix(X)` but allows for `numpy.inf`entries. Please check if that is clean enough for your taste and if `hdbscan_.py` is the place you would leave that function in.  
Something else that I couldn't reliably judge is if copying the `distance_matrix` in line 78 is necessary or can be omitted.  
At the moment no "error handling" is in place for when the minimum spanning tree can't be created anymore without having edge weights that are infinite. Depending on how much one trusts HDBSCAN users using this edge case, at least a warning message for that case might be a wise. If you think that might be a good idea, I'm happy to add one in a further revision.

I'm looking forward to your comments and suggestions.