### PR TITLE
add doc for missing distances support

### DIFF
--- a/docs/basic_hdbscan.rst
+++ b/docs/basic_hdbscan.rst
@@ -280,7 +280,11 @@ distance, etc. Again, this is all fine as ``hdbscan`` supports a special
 metric called ``precomputed``. If you create the clusterer with the
 metric set to ``precomputed`` then the clusterer will assume that,
 rather than being handed a vector of points in a vector space, it is
-recieving an all pairs distance matrix.
+recieving an all pairs distance matrix. Missing distances can be
+indicated by ``numpy.inf``, which leads HDBSCAN to ignore these pairwise
+relationships as long as there exists a path between two points that
+contains defined distances (i.e. if there are too many distances
+missing, the clustering is going to fail).
 
 .. code:: python
 


### PR DESCRIPTION
Finally delivering some minimal documentation for the support of missing distances in the precomputed metric case (#189).

I'm uncertain whether the bit about the path of defined distances between two points makes sense without explicitly mentioning the MST, but the context of the "Basic HDBSCAN" doc page suggested a minimally technical explanation.  
Feel free to help me find the right balance of jargon and ease of use.

Also, @lmcinnes, are there other places you would like to see information about the missing distances support? Like for example the `fit()` and `fit_predict()` docstrings?