### PR TITLE
Add pyporject.toml file to specify build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "setuptools",
+  "wheel",
+  "cython",
+  "numpy"
+]


### PR DESCRIPTION
As of [v10 of `pip`](https://pip.pypa.io/en/stable/reference/pip/#pep-518-support) [PEP 518](https://www.python.org/dev/peps/pep-0518/) is supported.  This allows for a `pyproject.toml` file to be created that specifies any build-system  requirements that need to be installed *before* the `setup.py` file is  run.  This solves the issue with pip needing `cython` and `numpy` before they are installed.

This has the added benefit that any packages that include this one as a `requirement` don't need to make sure `cython` is installed first (I am currently running into this issue with the package I am writing).

This has been tested with the command `pip install .` in clean python  environments in both python 3.6 and 3.7.  Pip was able to install the package and all dependencies in the correct order.