### PR TITLE
Better error message in sparse precomputed mode. [#253]

### DIFF
--- a/hdbscan/_hdbscan_reachability.pyx
+++ b/hdbscan/_hdbscan_reachability.pyx
@@ -60,7 +60,7 @@ def mutual_reachability(distance_matrix, min_points=5, alpha=1.0):
 
 
 cpdef sparse_mutual_reachability(object lil_matrix, np.intp_t min_points=5,
-                                 float alpha=1.0):
+                                 float alpha=1.0, float max_dist=0.):
 
     cdef np.intp_t i
     cdef np.intp_t j
@@ -90,6 +90,8 @@ cpdef sparse_mutual_reachability(object lil_matrix, np.intp_t min_points=5,
         mr_dist = max(core_distance[i], core_distance[j], lil_matrix[i, j])
         if np.isfinite(mr_dist):
             result[i, j] = mr_dist
+        elif max_dist > 0:
+            result[i, j] = max_dist
 
     return result.tocsr()
 

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -131,20 +131,32 @@ def _hdbscan_sparse_distance_matrix(X, min_samples=5, alpha=1.0,
                                     metric='minkowski', p=2, leaf_size=40,
                                     gen_min_span_tree=False, **kwargs):
     assert issparse(X)
+    # Check for connected component on X
+    if csgraph.connected_components(X, directed=False, return_labels=False) > 1:
+        raise ValueError('Sparse distance matrix has multiple connected '
+                         'components!\nThat is, there exist groups of points '
+                         'that are completely disjoint -- there are no distance '
+                         'relations connecting them\n'
+                         'Run hdbscan on each component.')
 
     lil_matrix = X.tolil()
 
     # Compute sparse mutual reachability graph
+    # if max_dist > 0, max distance to use when the reachability is infinite
+    max_dist = kwargs.get("max_dist", 0.)
     mutual_reachability_ = sparse_mutual_reachability(lil_matrix,
-                                                      min_points=min_samples)
-
+                                                      min_points=min_samples,
+                                                      max_dist=max_dist)
+    # Check connected component on mutual reachability
+    # If more than one component, it means that even if the distance matrix X
+    # has one component, there exists with less than `min_samples` neighbors
     if csgraph.connected_components(mutual_reachability_, directed=False,
                                     return_labels=False) > 1:
-        raise ValueError('Sparse distance matrix has multiple connected'
-                         ' components!\nThat is, there exist groups of points '
-                         'that are completely disjoint -- there are no distance '
-                         'relations connecting them\n'
-                         'Run hdbscan on each component.')
+        raise ValueError(('There exists points with less than %s neighbors. '
+                          'Ensure your distance matrix has non zeros values for '
+                          'at least `min_sample`=%s neighbors for each points (i.e. K-nn graph), '
+                          'or specify a `max_dist` to use when distances are missing.')
+                         % (min_samples, min_samples))
 
     # Compute the minimum spanning tree for the sparse graph
     sparse_min_spanning_tree = csgraph.minimum_spanning_tree(


### PR DESCRIPTION
Address #253,

* More explanatory message when the mutual reachability matrix has more than one component, in sparse precomputed distance mode.

* Add a `max_dist` parameter to the `sparse_mutual_reachability` fct, so that when it's infinite, it takes this value. I guess it won't provide good density estimation around those points, but can be helpful to make the whole clustering works anyway.
