### PR TITLE
Wraps output of condensed_tree's minimum in a list

### DIFF
--- a/hdbscan/plots.py
+++ b/hdbscan/plots.py
@@ -43,7 +43,7 @@ def _get_leaves(condensed_tree):
     cluster_tree = condensed_tree[condensed_tree['child_size'] > 1]
     if cluster_tree.shape[0] == 0:
         # Return the only cluster, the root
-        return condensed_tree['parent'].min()
+        return [condensed_tree['parent'].min()]
 
     root = cluster_tree['parent'].min()
     return _recurse_leaf_dfs(cluster_tree, root)


### PR DESCRIPTION
This only happens when a single cluster is returned, and when using the `"leaf"` argument for the clustering.
The result of `condensed_tree['parent'].min()` is an integer, but the output of the `_get_leaves` function should be a list, otherwise a `TypeError` can be raised.
For instance in `predictions.py`, with `list(selected_cluster)`:
```python
selected_clusters = condensed_tree._select_clusters()
self.cluster_map = {c: n for n, c in enumerate(sorted(list(selected_clusters)))}
```
and  `_select_clusters()` is a method of `CondensedTree` defined in `plots.py`, which calls `_get_leaves`
```python
def _select_clusters(self):
    [ ... ]
    elif self.cluster_selection_method == 'leaf':
        return _get_leaves(self._raw_tree)
```