### PR TITLE
Add alpha parameter to sparse distance matrices

### DIFF
--- a/hdbscan/_hdbscan_reachability.pyx
+++ b/hdbscan/_hdbscan_reachability.pyx
@@ -81,6 +81,9 @@ cpdef sparse_mutual_reachability(object lil_matrix, np.intp_t min_points=5,
         else:
             core_distance[i] = np.infty
 
+    if alpha != 1.0:
+        lil_matrix = lil_matrix / alpha
+
     nz_row_data, nz_col_data = lil_matrix.nonzero()
 
     for n in range(nz_row_data.shape[0]):

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -146,7 +146,8 @@ def _hdbscan_sparse_distance_matrix(X, min_samples=5, alpha=1.0,
     max_dist = kwargs.get("max_dist", 0.)
     mutual_reachability_ = sparse_mutual_reachability(lil_matrix,
                                                       min_points=min_samples,
-                                                      max_dist=max_dist)
+                                                      max_dist=max_dist,
+                                                      alpha=alpha)
     # Check connected component on mutual reachability
     # If more than one component, it means that even if the distance matrix X
     # has one component, there exists with less than `min_samples` neighbors


### PR DESCRIPTION
This adds support for the alpha parameter in the same way it is done for dense matrices.

The change seems obvious so I'm not sure if there is a reason alpha support was missing? Are there fundamental problems using it in the sparse code path?