### PR TITLE
fix import errors for scikit-learn 0.21

### DIFF
--- a/hdbscan/__init__.py
+++ b/hdbscan/__init__.py
@@ -2,4 +2,6 @@ from .hdbscan_ import HDBSCAN, hdbscan
 from .robust_single_linkage_ import RobustSingleLinkage, robust_single_linkage
 from .validity import validity_index
 from .prediction import approximate_predict, membership_vector, all_points_membership_vectors
+from .utils import if_matplotlib
+
 

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -10,11 +10,11 @@ from sklearn.base import BaseEstimator, ClusterMixin
 from sklearn.metrics import pairwise_distances
 from scipy.sparse import issparse
 from sklearn.neighbors import KDTree, BallTree
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from sklearn.externals import six
 from warnings import warn
 from sklearn.utils import check_array
-from sklearn.externals.joblib.parallel import cpu_count
+from joblib.parallel import cpu_count
 
 from scipy.sparse import csgraph
 

--- a/hdbscan/robust_single_linkage_.py
+++ b/hdbscan/robust_single_linkage_.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator, ClusterMixin
 from sklearn.metrics import pairwise_distances
 from scipy.sparse import issparse
 
-from sklearn.externals.joblib import Memory
+from joblib import Memory
 from sklearn.externals import six
 from sklearn.utils import check_array
 

--- a/hdbscan/tests/test_hdbscan.py
+++ b/hdbscan/tests/test_hdbscan.py
@@ -16,14 +16,14 @@ from sklearn.utils.testing import (assert_equal,
                                    assert_raises,
                                    assert_in,
                                    assert_not_in,
-                                   assert_no_warnings,
-                                   if_matplotlib)
+                                   assert_no_warnings)
 from hdbscan import (HDBSCAN,
                      hdbscan,
                      validity_index,
                      approximate_predict,
                      membership_vector,
-                     all_points_membership_vectors)
+                     all_points_membership_vectors,
+                     if_matplotlib)
 # from sklearn.cluster.tests.common import generate_clustered_data
 from sklearn.datasets import make_blobs
 from sklearn.utils import shuffle

--- a/hdbscan/tests/test_rsl.py
+++ b/hdbscan/tests/test_rsl.py
@@ -12,9 +12,9 @@ from sklearn.utils.testing import (assert_equal,
                                    assert_raises,
                                    assert_in,
                                    assert_not_in,
-                                   assert_no_warnings,
-                                   if_matplotlib)
+                                   assert_no_warnings)
 from hdbscan import RobustSingleLinkage, robust_single_linkage
+
 # from sklearn.cluster.tests.common import generate_clustered_data
 
 from sklearn import datasets

--- a/hdbscan/utils.py
+++ b/hdbscan/utils.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+from nose import SkipTest
+
+
+def if_matplotlib(func):
+    """Test decorator that skips test if matplotlib not installed.
+
+    Parameters
+    ----------
+    func
+    """
+    @wraps(func)
+    def run_test(*args, **kwargs):
+        try:
+            import matplotlib
+            matplotlib.use('Agg', warn=False)
+            # this fails if no $DISPLAY specified
+            import matplotlib.pyplot as plt
+            plt.figure()
+        except ImportError:
+            raise SkipTest('Matplotlib not available.')
+        else:
+            return func(*args, **kwargs)
+    return run_test

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cython>=0.27
 numpy>=1.16.0
 scipy >= 0.9
 scikit-learn>=0.17
-
+joblib


### PR DESCRIPTION
I understand if this PR is rejected, I just wanted to get the ball rolling as we have to pin scikit-learn to <0.21 for hdbscan alone currently.

scikit-learn gives deprecation warnings about sklearn.externals.joblib being removed by 0.23. As far as I can tell they have also removed sklearn.externals.joblib.parallel by 0.21, so this import fails. Recent versions of scikit-learn depend on joblib, but older versions do not. You could solve this with a conditional install, or just always use joblib. I went for the latter solution.

As far as I can tell, they have also removed the convenience function if_matplotlib.

My changes are:
- Create .utils with if_matplotlib since the function is easily self-contained
- Add joblib to dependencies and move all imports from sklearn.externals.joblib to joblib

I didn't see a pattern for testing utils, and I don't know what version you'd like to pin joblib to, so this is the best I could come up with.