### PR TITLE
Fix `DuplicationWarning` by importing the original libraries.

### DIFF
--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -68,7 +68,7 @@ from sklearn.neighbors import KDTree, BallTree
 import dist_metrics as dist_metrics
 cimport dist_metrics as dist_metrics
 
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 cdef np.double_t INF = np.inf
 

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -11,7 +11,7 @@ from sklearn.metrics import pairwise_distances
 from scipy.sparse import issparse
 from sklearn.neighbors import KDTree, BallTree
 from joblib import Memory
-from sklearn.externals import six
+import six
 from warnings import warn
 from sklearn.utils import check_array
 from joblib.parallel import cpu_count

--- a/hdbscan/robust_single_linkage_.py
+++ b/hdbscan/robust_single_linkage_.py
@@ -9,7 +9,7 @@ from sklearn.metrics import pairwise_distances
 from scipy.sparse import issparse
 
 from joblib import Memory
-from sklearn.externals import six
+import six
 from sklearn.utils import check_array
 
 from ._hdbscan_linkage import mst_linkage_core, mst_linkage_core_vector, label

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.16.0
 scipy >= 0.9
 scikit-learn>=0.17
 joblib
+six


### PR DESCRIPTION
## 1. Overview

This PR addresses https://github.com/scikit-learn-contrib/hdbscan/issues/322.
When `hdbscan` is imported, the following `DuplicationWarning` is raised because `sklearn` will drop `six` and `joblib` from `externals` in the future version (0.2.3).
![image](https://user-images.githubusercontent.com/8693216/64935309-736ba900-d88b-11e9-8918-1061ca90441e.png)
Importing those libraries directory circumvents the problem.

## 2. Implementation details

* Add `six` to `requirements.txt`.
* Substitute import statements in `hdbscan/_hdbscan_boruvka.pyx`, `hdbscan/hdbscan_.py`,  and `hdbscan/robust_single_linkage_.py`. 
