### PR TITLE
fix: joblib issue with frozen executables

### DIFF
--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -408,7 +408,7 @@ cdef class KDTreeBoruvkaAlgorithm (object):
                                           self.num_points])
                         ]
 
-            knn_data = Parallel(n_jobs=self.n_jobs)(
+            knn_data = Parallel(n_jobs=self.n_jobs, prefer="threads")(
                 delayed(_core_dist_query,
                         check_pickle=False)
                 (self.core_dist_tree, points,
@@ -1012,7 +1012,7 @@ cdef class BallTreeBoruvkaAlgorithm (object):
                                                   self.num_points])
                         ]
 
-            knn_data = Parallel(n_jobs=self.n_jobs)(
+            knn_data = Parallel(n_jobs=self.n_jobs, prefer="threads")(
                 delayed(_core_dist_query,
                         check_pickle=False)
                 (self.core_dist_tree, points,


### PR DESCRIPTION
I created this PR to discuss an issue of the new joblib loky parallel processing backend with frozen apps (introduced when moving from sklearn.externals.joblib to joblib).

My workaround may not be for everyone, so please review and comment first.

I'm using HDBSCAN as a dependency in a package that is frozen using cx_freeze. The frozen app leads to a multiprocessing bomb. The workaround is to use `Parallel(n_jobs=self.n_jobs, prefer="threads")`. According to the [joblib docs](https://joblib.readthedocs.io/en/latest/parallel.html), this can also speed up processing - but it depends (and I don't know whether this always applies to the use in HDBSCAN). If nothing speaks against always using `prefer="threads"`, I suggest merging this PR.

There's a similar issue described [here][1] (that led me to the workaround).

I've also created an issue for [joblib][2]

[1]: https://stackoverflow.com/a/54901651/4556479
[2]: https://github.com/joblib/joblib/issues/1002