### PR TITLE
docs/faq.rst: Fix references

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -12,7 +12,7 @@ parameter. By default, if not otherwise set, this value is set to the same
 value as ``min_cluster_size``. You can set it independently if you wish by
 specifying it separately. The lower the value, the less noise you'll get, but
 there are limits, and it is possible that you simply have noisy data. See
-:any:`_min_samples_label` for more details.
+:any:`min_samples <min_samples_label>` for more details.
 
 Q: I mostly just get one large cluster; I want smaller clusters.
 ----------------------------------------------------------------
@@ -22,7 +22,7 @@ that means your data is essentially a large glob with some small outlying
 clusters -- there may be structure to the glob, but compared to how well
 separated those other small clusters are, it doesn't really show up. You may,
 however, want to get at that more fine grained structure. You can do that,
-and what you are looking for is leaf clustering :any:`_leaf_cluster_label` .
+and what you are looking for is :any:`leaf clustering <leaf_clustering_label>`.
 
 Q: HDBSCAN is failing to separate the clusters I think it should.
 -----------------------------------------------------------------


### PR DESCRIPTION
This fixes the references to parameter selection sections in the FAQ.