### PR TITLE
#384 fixed error in arccos metric formula

### DIFF
--- a/hdbscan/dist_metrics.pyx
+++ b/hdbscan/dist_metrics.pyx
@@ -1073,7 +1073,7 @@ cdef class ArccosDistance(DistanceMetric):
             d += x1[j] * x2[j]
             norm1 += x1[j] * x1[j]
             norm2 += x2[j] * x2[j]
-        return acos(1.0 - d / sqrt(norm1 * norm2)) / M_PI
+        return acos(d / sqrt(norm1 * norm2)) / M_PI
 
 
 # ------------------------------------------------------------


### PR DESCRIPTION
This is a fix for #348 

It is a quite simple fix of a typo in the code. I modified line 1076 in dist_metrics.pyx file from:

```
return acos(1.0 - d / sqrt(norm1 * norm2)) / M_PI
```

to this

```
return acos(d / sqrt(norm1 * norm2)) / M_PI
```


