### PR TITLE
Change weighted_cluster_medoid to use argmin (not argmax)

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -1024,7 +1024,7 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
                                       **self._metric_kwargs)
 
         dist_mat = dist_mat * cluster_membership_strengths
-        medoid_index = np.argmax(dist_mat.sum(axis=1))
+        medoid_index = np.argmin(dist_mat.sum(axis=1))
         return cluster_data[medoid_index]
 
 


### PR DESCRIPTION
Fix for https://github.com/scikit-learn-contrib/hdbscan/issues/353