### PR TITLE
Faster union find

### DIFF
--- a/hdbscan/_hdbscan_linkage.pyx
+++ b/hdbscan/_hdbscan_linkage.pyx
@@ -178,9 +178,7 @@ cdef class UnionFind (object):
         self.size[self.next_label] = self.size[m] + self.size[n]
         self.parent[m] = self.next_label
         self.parent[n] = self.next_label
-        self.size[self.next_label] = self.size[m] + self.size[n]
         self.next_label += 1
-
         return
 
     cdef np.intp_t fast_find(self, np.intp_t n):
@@ -188,9 +186,10 @@ cdef class UnionFind (object):
         p = n
         while self.parent[n] != -1:
             n = self.parent[n]
-        # label up to the root
-        while self.parent[p] != n:
-            p, self.parent[p] = self.parent[p], n
+        # label up to the root if this is not the root already
+        if p != n:
+            while self.parent[p] != n:
+                p, self.parent[p] = self.parent[p], n
         return n
 
 

--- a/hdbscan/_hdbscan_linkage.pyx
+++ b/hdbscan/_hdbscan_linkage.pyx
@@ -182,14 +182,16 @@ cdef class UnionFind (object):
         return
 
     cdef np.intp_t fast_find(self, np.intp_t n):
-        cdef np.intp_t p
+        cdef np.intp_t p, tmp
         p = n
         while self.parent[n] != -1:
             n = self.parent[n]
         # label up to the root if this is not the root already
         if p != n:
             while self.parent[p] != n:
-                p, self.parent[p] = self.parent[p], n
+                tmp = self.parent[p]
+                self.parent[p] = n
+                p = tmp
         return n
 
 

--- a/hdbscan/_hdbscan_linkage.pyx
+++ b/hdbscan/_hdbscan_linkage.pyx
@@ -186,11 +186,11 @@ cdef class UnionFind (object):
     cdef np.intp_t fast_find(self, np.intp_t n):
         cdef np.intp_t p
         p = n
-        while self.parent_arr[n] != -1:
-            n = self.parent_arr[n]
+        while self.parent[n] != -1:
+            n = self.parent[n]
         # label up to the root
-        while self.parent_arr[p] != n:
-            p, self.parent_arr[p] = self.parent_arr[p], n
+        while self.parent[p] != n:
+            p, self.parent[p] = self.parent[p], n
         return n
 
 


### PR DESCRIPTION
This speeds up `single_linkage` by about two orders of magnitude by using direct array access in `fast_find` which Cython can compile into a pure C loop.

I saw in the commit history that this was attempted before but abandoned due to unexplained crashes. The reason is that the current code is actually buggy and only works because python's wraparound indexing hides the problem. When using raw pointer access the bug leads to heap corruption and subsequent random crashes. A simple check to only label if we are not at the root already fixes this.

Also fixes #321 which should further improve overall performance.