### PR TITLE
Faster sparse reachability

### DIFF
--- a/hdbscan/_hdbscan_reachability.pyx
+++ b/hdbscan/_hdbscan_reachability.pyx
@@ -68,6 +68,8 @@ cpdef sparse_mutual_reachability(object distance_matrix, np.intp_t min_points=5,
 
     # tocsr() is a fast noop if distance_matrix is already CSR
     D = distance_matrix.tocsr()
+    if D.shape != (D.shape[0], D.shape[0]):
+        raise Exception("Distance matrix must be 2D square shaped instead of {}".format(D.shape))
     # Convert to smallest supported data type if necessary
     if D.dtype not in (np.float32, np.float64):
         if D.dtype <= np.dtype(np.float32):
@@ -103,18 +105,18 @@ ctypedef fused mr_data_t:
     np.float32_t
     np.float64_t
 
-cdef sparse_mr_fast(np.ndarray[dtype=mr_data_t, ndim=1] data,
-                    np.ndarray[dtype=mr_indx_t, ndim=1] indices,
-                    np.ndarray[dtype=mr_indx_t, ndim=1] indptr,
+cdef sparse_mr_fast(np.ndarray[dtype=mr_data_t, ndim=1, mode='c'] data,
+                    np.ndarray[dtype=mr_indx_t, ndim=1, mode='c'] indices,
+                    np.ndarray[dtype=mr_indx_t, ndim=1, mode='c'] indptr,
                     mr_indx_t min_points,
                     mr_data_t alpha,
                     mr_data_t max_dist):
     cdef mr_indx_t row, col, colptr
     cdef mr_data_t mr_dist
-    cdef np.ndarray[dtype=mr_data_t, ndim=1] row_data
-    cdef np.ndarray[dtype=mr_data_t, ndim=1] core_distance
+    cdef np.ndarray[dtype=mr_data_t, ndim=1, mode='c'] row_data
+    cdef np.ndarray[dtype=mr_data_t, ndim=1, mode='c'] core_distance
 
-    core_distance = np.empty(data.shape[0], dtype=data.dtype)
+    core_distance = np.empty(indptr.shape[0]-1, dtype=data.dtype)
 
     for row in range(indptr.shape[0]-1):
         row_data = data[indptr[row]:indptr[row+1]].copy()

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -78,8 +78,12 @@ def _hdbscan_generic(X, min_samples=5, alpha=1.0, metric='minkowski', p=2,
         #   sklearn.metrics.pairwise_distances handle it,
         #   enables the usage of numpy.inf in the distance
         #   matrix to indicate missing distance information.
-        # Need copy because distance_matrix may be modified if sparse
-        distance_matrix = X.copy()
+        # Give the user the option to have the distance matrix
+        #   modified to save memory.
+        if kwargs.get("overwrite", False):
+            distance_matrix = X
+        else:
+            distance_matrix = X.copy()
     else:
         distance_matrix = pairwise_distances(X, metric=metric, **kwargs)
 

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -161,7 +161,7 @@ def _hdbscan_sparse_distance_matrix(X, min_samples=5, alpha=1.0,
 
     # Compute the minimum spanning tree for the sparse graph
     sparse_min_spanning_tree = csgraph.minimum_spanning_tree(
-        mutual_reachability_)
+        mutual_reachability_, overwrite=True)
 
     # Convert the graph to scipy cluster array format
     nonzeros = sparse_min_spanning_tree.nonzero()

--- a/hdbscan/tests/test_hdbscan.py
+++ b/hdbscan/tests/test_hdbscan.py
@@ -154,6 +154,12 @@ def test_hdbscan_sparse_distance_matrix():
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
     assert_equal(n_clusters_2, n_clusters)
 
+    # Verify single and double precision return same results
+    assert_equal(D.dtype, np.double)
+    labels_double = hdbscan(D, metric='precomputed')[0]
+    labels_single = hdbscan(D.astype(np.single), metric='precomputed')[0]
+    assert_array_equal(labels_single, labels_double)
+
 
 def test_hdbscan_feature_vector():
     labels, p, persist, ctree, ltree, mtree = hdbscan(X)


### PR DESCRIPTION
This replaces `sparse_mutual_reachability` with a version which is 137 times faster for my datasets. The algorithm is essentially identical but it operates on the CSR matrix directly, omitting conversion to LIL and back which is both very slow and uses a lot of unnecessary memory.

The code supports both float32 and float64 natively which allows for more memory savings if double precision is not required. Additionally we save another unnecessary copy by passing `overwrite=True` to `csgraph.minimum_spanning_tree`.

Lastly the user can use `overwrite=True` when calling hdbscan to indicate the distance matrix they pass can be modified in place, saving yet another copy.

Overall memory usage can be cut to 1/4th which makes it possible to deal with very large distance matrices. I have successfully clustered graphs with 10M nodes and 1B edges.
