### PR TITLE
Faster cluster selection

### DIFF
--- a/hdbscan/flat.py
+++ b/hdbscan/flat.py
@@ -851,19 +851,9 @@ def _new_select_clusters(condensed_tree,
                     is_cluster[c] = False
 
     elif cluster_selection_method == 'leaf':
-        leaves = set(get_cluster_tree_leaves(cluster_tree))
-        if len(leaves) == 0:
-            for c in is_cluster:
-                is_cluster[c] = False
-            is_cluster[tree['parent'].min()] = True
-
-        if cluster_selection_epsilon != 0.0:
-            selected_clusters = epsilon_search(leaves, cluster_tree,
-                                               cluster_selection_epsilon,
-                                               allow_single_cluster)
-        else:
-            selected_clusters = leaves
-
+        selected_clusters = set(get_cluster_tree_leaves(cluster_tree,
+                                                        cluster_selection_epsilon,
+                                                        allow_single_cluster))
         for c in is_cluster:
             if c in selected_clusters:
                 is_cluster[c] = True


### PR DESCRIPTION
This PR makes performance improvements to `epsilon_search` and `get_cluster_tree_leaves` by optimizing Cython compilation and exploiting how the tree is stored.

The `epsilon_search` improvements are for _eom_ selection.

For _leaf_ selection `epsilon_search` is no longer used and the epsilon criteria is checked during `get_cluster_tree_leaves`. This avoids traversing the tree down to the leaves and then finding the leaves again to traverse up.