### PR TITLE
_find_neighbor_and_lambda off-by-one error

### DIFF
--- a/hdbscan/prediction.py
+++ b/hdbscan/prediction.py
@@ -174,7 +174,7 @@ def _find_neighbor_and_lambda(neighbor_indices, neighbor_distances,
         The lambda value at which this point joins/merges with `neighbor`.
     """
     neighbor_core_distances = core_distances[neighbor_indices]
-    point_core_distances = neighbor_distances[min_samples] * np.ones(
+    point_core_distances = neighbor_distances[min_samples - 1] * np.ones(
         neighbor_indices.shape[0])
     mr_distances = np.vstack((
         neighbor_core_distances,


### PR DESCRIPTION
Hi there, I believe there is an off-by-one error in taking the point to predict core distance.
Currently it's taking the 6th neighbor (if min_samples is 5) as the core distance.
It's what solved my issue in #381 , although you are the best to judge whether it's logically correct depending on the rest of the implementation.
Thanks and regards.