### PR TITLE
Fix build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
   matrix:
     - DISTRIB="conda" PYTHON_VERSION="3.7"
       NUMPY_VERSION="1.15.3" SCIPY_VERSION="1.2.1" CYTHON_VERSION="0.28.5"
-    - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
-      NUMPY_VERSION="1.10.4" SCIPY_VERSION="0.17.0" CYTHON_VERSION="0.23.5"
 
 install: source ci_scripts/install.sh
 script: bash ci_scripts/test.sh

--- a/hdbscan/tests/test_flat.py
+++ b/hdbscan/tests/test_flat.py
@@ -15,9 +15,6 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import train_test_split
 from sklearn.utils._testing import assert_array_equal, assert_array_less
 
-def assert_equal(a, b):
-    assert(a == b)
-
 # Ignore future warnings thrown by sklearn
 warnings.filterwarnings("ignore", category=FutureWarning)
 
@@ -185,7 +182,7 @@ def test_approx_predict_same_clusters():
 
     # Then, the number of clusters produced must match the original n_clusters
     n_clusters_out = n_clusters_from_labels(labels_flat)
-    assert_equal(n_clusters_out, n_clusters)
+    assert(n_clusters_out == n_clusters)
     # and all probabilities are <= 1.
     assert_array_less(proba_flat, np.ones(len(proba_flat))+1.e-14)
     return
@@ -208,7 +205,7 @@ def test_approx_predict_diff_clusters():
 
     # Then, the requested number of clusters must be produced
     n_clusters_out = n_clusters_from_labels(labels_flat)
-    assert_equal(n_clusters_out, n_clusters_predict)
+    assert(n_clusters_out == n_clusters_predict)
     # and all probabilities are <= 1.
     assert_array_less(proba_flat, np.ones(len(proba_flat))+1.e-14)
 
@@ -224,7 +221,7 @@ def test_approx_predict_diff_clusters():
         assert "Cannot predict" in str(w[-1].message)
     # But the requested number of clusters must still be produced using 'leaf'
     n_clusters_out = n_clusters_from_labels(labels_flat)
-    assert_equal(n_clusters_out, n_clusters_predict)
+    assert(n_clusters_out == n_clusters_predict)
     # and all probabilities are <= 1.
     assert_array_less(proba_flat, np.ones(len(proba_flat))+1.e-14)
     return
@@ -242,10 +239,9 @@ def test_mem_vec_same_clusters():
     memberships = membership_vector_flat(clusterer, X_test)
 
     # Then the number of clusters in memberships matches those of clusterer,
-    assert_equal(memberships.shape[1],
-                 n_clusters_from_labels(clusterer.labels_))
+    assert(memberships.shape[1] == n_clusters_from_labels(clusterer.labels_))
     # and the number of points should equal those in the test set
-    assert_equal(len(memberships), len(X_test))
+    assert(len(memberships) == len(X_test))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
 
@@ -258,9 +254,9 @@ def test_mem_vec_same_clusters():
     memberships = membership_vector_flat(clusterer, X_test)
 
     # Then the number of clusters in memberships matches those of clusterer,
-    assert_equal(memberships.shape[1], n_clusters_fit)
+    assert(memberships.shape[1] == n_clusters_fit)
     # and the number of points should equal those in the test set
-    assert_equal(len(memberships), len(X_test))
+    assert(len(memberships) == len(X_test))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
     return
@@ -284,9 +280,9 @@ def test_mem_vec_diff_clusters():
                                          n_clusters=n_clusters_predict)
 
     # Then the number of clusters in memberships should be as requested,
-    assert_equal(memberships.shape[1], n_clusters_predict)
+    assert(memberships.shape[1] == n_clusters_predict)
     # and the number of points should equal those in the test set
-    assert_equal(len(memberships), len(X_test))
+    assert(len(memberships) == len(X_test))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
 
@@ -301,9 +297,9 @@ def test_mem_vec_diff_clusters():
                                          n_clusters=n_clusters_predict)
 
     # Then the number of clusters in memberships should be as requested,
-    assert_equal(memberships.shape[1], n_clusters_predict)
+    assert(memberships.shape[1] == n_clusters_predict)
     # and the number of points should equal those in the test set
-    assert_equal(len(memberships), len(X_test))
+    assert(len(memberships) == len(X_test))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
     return
@@ -322,10 +318,9 @@ def test_all_points_mem_vec_same_clusters():
     memberships = all_points_membership_vectors_flat(clusterer)
 
     # Then the number of clusters in memberships matches those of clusterer,
-    assert_equal(memberships.shape[1],
-                 n_clusters_from_labels(clusterer.labels_))
+    assert(memberships.shape[1] == n_clusters_from_labels(clusterer.labels_))
     # and the number of points should equal those in the training set
-    assert_equal(len(memberships), len(X))
+    assert(len(memberships) == len(X))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
 
@@ -338,10 +333,9 @@ def test_all_points_mem_vec_same_clusters():
     memberships = all_points_membership_vectors_flat(clusterer)
 
     # Then the number of clusters in memberships matches those of clusterer,
-    assert_equal(memberships.shape[1],
-                 n_clusters_from_labels(clusterer.labels_))
+    assert(memberships.shape[1] == n_clusters_from_labels(clusterer.labels_))
     # and the number of points should equal those in the training set
-    assert_equal(len(memberships), len(X))
+    assert(len(memberships) == len(X))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
     return
@@ -365,9 +359,9 @@ def test_all_points_mem_vec_diff_clusters():
                         clusterer, n_clusters=n_clusters_predict)
 
     # Then the number of clusters in memberships should be as requested,
-    assert_equal(memberships.shape[1], n_clusters_predict)
+    assert(memberships.shape[1] == n_clusters_predict)
     # and the number of points should equal those in the training set
-    assert_equal(len(memberships), len(X))
+    assert(len(memberships) == len(X))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
 
@@ -382,9 +376,9 @@ def test_all_points_mem_vec_diff_clusters():
                         clusterer, n_clusters=n_clusters_predict)
 
     # Then the number of clusters in memberships should be as requested,
-    assert_equal(memberships.shape[1], n_clusters_predict)
+    assert(memberships.shape[1] == n_clusters_predict)
     # and the number of points should equal those in the training set
-    assert_equal(len(memberships), len(X))
+    assert(len(memberships) == len(X))
     # and all probabilities are <= 1.
     assert_array_less(memberships, np.ones(memberships.shape)+1.e-14)
     return

--- a/hdbscan/tests/test_flat.py
+++ b/hdbscan/tests/test_flat.py
@@ -13,10 +13,10 @@ from hdbscan.flat import (HDBSCAN_flat,
 from sklearn.datasets import make_blobs, make_moons
 from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import train_test_split
-from sklearn.utils._testing import (assert_equal,
-                                   assert_array_equal,
-                                   assert_array_less)
+from sklearn.utils._testing import assert_array_equal, assert_array_less
 
+def assert_equal(a, b):
+    assert(a == b)
 
 # Ignore future warnings thrown by sklearn
 warnings.filterwarnings("ignore", category=FutureWarning)

--- a/hdbscan/tests/test_flat.py
+++ b/hdbscan/tests/test_flat.py
@@ -13,7 +13,7 @@ from hdbscan.flat import (HDBSCAN_flat,
 from sklearn.datasets import make_blobs, make_moons
 from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import train_test_split
-from sklearn.utils.testing import (assert_equal,
+from sklearn.utils._testing import (assert_equal,
                                    assert_array_equal,
                                    assert_array_less)
 

--- a/hdbscan/tests/test_hdbscan.py
+++ b/hdbscan/tests/test_hdbscan.py
@@ -480,6 +480,7 @@ def test_hdbscan_approximate_predict_score():
     # wrong dimensions error
     assert_raises(ValueError, approximate_predict_scores, clusterer, np.array([[1, 2, 3]]))
     with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         approximate_predict_scores(clusterer, np.array([[1.5, -1.0]]))
         # no clusters warning
         assert 'Clusterer does not have any defined clusters' in str(w[-1].message)

--- a/hdbscan/tests/test_hdbscan.py
+++ b/hdbscan/tests/test_hdbscan.py
@@ -10,13 +10,9 @@ from scipy.spatial import distance
 from scipy import sparse
 from scipy import stats
 from sklearn.utils.estimator_checks import check_estimator
-from sklearn.utils.testing import (assert_equal,
-                                   assert_array_equal,
+from sklearn.utils._testing import (assert_array_equal,
                                    assert_array_almost_equal,
-                                   assert_raises,
-                                   assert_in,
-                                   assert_not_in,
-                                   assert_no_warnings)
+                                   assert_raises)
 from hdbscan import (HDBSCAN,
                      hdbscan,
                      validity_index,
@@ -124,11 +120,11 @@ def test_hdbscan_distance_matrix():
     labels, p, persist, ctree, ltree, mtree = hdbscan(D, metric='precomputed')
     # number of clusters, ignoring noise if present
     n_clusters_1 = len(set(labels)) - int(-1 in labels)  # ignore noise
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(metric="precomputed").fit(D).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
     validity = validity_index(D, labels, metric='precomputed', d=2)
     assert_greater_equal(validity, 0.6)
@@ -147,22 +143,22 @@ def test_hdbscan_sparse_distance_matrix():
     labels, p, persist, ctree, ltree, mtree = hdbscan(D, metric='precomputed')
     # number of clusters, ignoring noise if present
     n_clusters_1 = len(set(labels)) - int(-1 in labels)  # ignore noise
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(metric="precomputed",
                      gen_min_span_tree=True).fit(D).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_hdbscan_feature_vector():
     labels, p, persist, ctree, ltree, mtree = hdbscan(X)
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN().fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
     validity = validity_index(X, labels)
     assert_greater_equal(validity, 0.4)
@@ -172,12 +168,12 @@ def test_hdbscan_prims_kdtree():
     labels, p, persist, ctree, ltree, mtree = hdbscan(X,
                                                       algorithm='prims_kdtree')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(algorithm='prims_kdtree',
                      gen_min_span_tree=True).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
     assert_raises(ValueError,
                   hdbscan,
@@ -190,12 +186,12 @@ def test_hdbscan_prims_balltree():
     labels, p, persist, ctree, ltree, mtree = hdbscan(
         X, algorithm='prims_balltree')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(algorithm='prims_balltree',
                      gen_min_span_tree=True).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
     assert_raises(ValueError,
                   hdbscan,
@@ -208,12 +204,12 @@ def test_hdbscan_boruvka_kdtree():
     labels, p, persist, ctree, ltree, mtree = hdbscan(
         X, algorithm='boruvka_kdtree')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(algorithm='boruvka_kdtree',
                      gen_min_span_tree=True).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
     assert_raises(ValueError,
                   hdbscan,
@@ -226,12 +222,12 @@ def test_hdbscan_boruvka_balltree():
     labels, p, persist, ctree, ltree, mtree = hdbscan(
         X, algorithm='boruvka_balltree')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(algorithm='boruvka_balltree',
                      gen_min_span_tree=True).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
     assert_raises(ValueError,
                   hdbscan,
@@ -243,12 +239,12 @@ def test_hdbscan_boruvka_balltree():
 def test_hdbscan_generic():
     labels, p, persist, ctree, ltree, mtree = hdbscan(X, algorithm='generic')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(algorithm='generic',
                      gen_min_span_tree=True).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_hdbscan_high_dimensional():
@@ -257,34 +253,34 @@ def test_hdbscan_high_dimensional():
     H = StandardScaler().fit_transform(H)
     labels, p, persist, ctree, ltree, mtree = hdbscan(H)
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(algorithm='best', metric='seuclidean',
                      V=np.ones(H.shape[1])).fit(H).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_hdbscan_best_balltree_metric():
     labels, p, persist, ctree, ltree, mtree = hdbscan(X, metric='seuclidean',
                                                       V=np.ones(X.shape[1]))
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(metric='seuclidean', V=np.ones(X.shape[1])).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_hdbscan_no_clusters():
     labels, p, persist, ctree, ltree, mtree = hdbscan(
         X, min_cluster_size=len(X) + 1)
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, 0)
+    assert(n_clusters_1 == 0)
 
     labels = HDBSCAN(min_cluster_size=len(X) + 1).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, 0)
+    assert(n_clusters_2 == 0)
 
 
 def test_hdbscan_min_cluster_size():
@@ -309,11 +305,11 @@ def test_hdbscan_callable_metric():
 
     labels, p, persist, ctree, ltree, mtree = hdbscan(X, metric=metric)
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = HDBSCAN(metric=metric).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_hdbscan_input_lists():
@@ -469,11 +465,11 @@ def test_hdbscan_outliers():
 def test_hdbscan_approximate_predict():
     clusterer = HDBSCAN(prediction_data=True).fit(X)
     cluster, prob = approximate_predict(clusterer, np.array([[-1.5, -1.0]]))
-    assert_equal(cluster, 2)
+    assert(cluster == 2)
     cluster, prob = approximate_predict(clusterer, np.array([[1.5, -1.0]]))
-    assert_equal(cluster, 1)
+    assert(cluster == 1)
     cluster, prob = approximate_predict(clusterer, np.array([[0.0, 0.0]]))
-    assert_equal(cluster, -1)
+    assert(cluster == -1)
 
 
 def test_hdbscan_approximate_predict_score():
@@ -596,7 +592,7 @@ def test_hdbscan_sparse():
 
     labels = HDBSCAN().fit(sparse_X).labels_
     n_clusters = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters, 3)
+    assert(n_clusters == 3)
 
 
 def test_hdbscan_caching():
@@ -607,7 +603,7 @@ def test_hdbscan_caching():
                       min_cluster_size=6).fit(X).labels_
     n_clusters1 = len(set(labels1)) - int(-1 in labels1)
     n_clusters2 = len(set(labels2)) - int(-1 in labels2)
-    assert_equal(n_clusters1, n_clusters2)
+    assert(n_clusters1 == n_clusters2)
 
 
 def test_hdbscan_centroids_medoids():
@@ -638,8 +634,8 @@ def test_hdbscan_allow_single_cluster_with_epsilon():
                      cluster_selection_method='eom',
                      allow_single_cluster=True).fit_predict(no_structure)
     unique_labels, counts = np.unique(labels, return_counts=True)
-    assert_equal(len(unique_labels), 2)
-    assert_equal(counts[unique_labels == -1], 46)
+    assert(len(unique_labels) == 2)
+    assert(counts[unique_labels == -1] == 46)
 
     # for this random seed an epsilon of 0.2 will produce exactly 2 noise
     # points at that cut in single linkage.
@@ -648,8 +644,8 @@ def test_hdbscan_allow_single_cluster_with_epsilon():
                      cluster_selection_method='eom',
                      allow_single_cluster=True).fit_predict(no_structure)
     unique_labels, counts = np.unique(labels, return_counts=True)
-    assert_equal(len(unique_labels), 2)
-    assert_equal(counts[unique_labels == -1], 2)
+    assert(len(unique_labels) == 2)
+    assert(counts[unique_labels == -1] == 2)
 
 
 # Disable for now -- need to refactor to meet newer standards

--- a/hdbscan/tests/test_rsl.py
+++ b/hdbscan/tests/test_rsl.py
@@ -7,12 +7,7 @@ import numpy as np
 from scipy.spatial import distance
 from scipy import sparse
 from sklearn.utils.estimator_checks import check_estimator
-from sklearn.utils.testing import (assert_equal,
-                                   assert_array_equal,
-                                   assert_raises,
-                                   assert_in,
-                                   assert_not_in,
-                                   assert_no_warnings)
+from sklearn.utils._testing import assert_array_equal, assert_raises
 from hdbscan import RobustSingleLinkage, robust_single_linkage
 
 # from sklearn.cluster.tests.common import generate_clustered_data
@@ -32,7 +27,6 @@ X, y = shuffle(X, y, random_state=7)
 X = StandardScaler().fit_transform(X)
 # X = generate_clustered_data(n_clusters=n_clusters, n_samples_per_cluster=50)
 
-
 def test_rsl_distance_matrix():
     D = distance.squareform(distance.pdist(X))
     D /= np.max(D)
@@ -40,21 +34,21 @@ def test_rsl_distance_matrix():
     labels, tree = robust_single_linkage(D, 0.4, metric='precomputed')
     # number of clusters, ignoring noise if present
     n_clusters_1 = len(set(labels)) - int(-1 in labels)  # ignore noise
-    assert_equal(n_clusters_1, 2)
+    assert(n_clusters_1 == 2)
 
     labels = RobustSingleLinkage(metric="precomputed").fit(D).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, 2)
+    assert(n_clusters_2 == 2)
 
 
 def test_rsl_feature_vector():
     labels, tree = robust_single_linkage(X, 0.4)
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = RobustSingleLinkage().fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_rsl_callable_metric():
@@ -63,11 +57,11 @@ def test_rsl_callable_metric():
 
     labels, tree = robust_single_linkage(X, 0.4, metric=metric)
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = RobustSingleLinkage(metric=metric).fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_rsl_input_lists():
@@ -78,32 +72,32 @@ def test_rsl_input_lists():
 def test_rsl_boruvka_balltree():
     labels, tree = robust_single_linkage(X, 0.45, algorithm='boruvka_balltree')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = RobustSingleLinkage(cut=0.45,
                                  algorithm='boruvka_balltree').fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_rsl_prims_balltree():
     labels, tree = robust_single_linkage(X, 0.4, algorithm='prims_balltree')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = RobustSingleLinkage(algorithm='prims_balltree').fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_rsl_prims_kdtree():
     labels, tree = robust_single_linkage(X, 0.4, algorithm='prims_kdtree')
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = RobustSingleLinkage(algorithm='prims_kdtree').fit(X).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 # def test_rsl_unavailable_hierarchy():
@@ -125,13 +119,13 @@ def test_rsl_high_dimensional():
     H = StandardScaler().fit_transform(H)
     labels, tree = robust_single_linkage(H, 5.5)
     n_clusters_1 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_1, n_clusters)
+    assert(n_clusters_1 == n_clusters)
 
     labels = RobustSingleLinkage(cut=5.5, algorithm='best',
                                  metric='seuclidean',
                                  metric_params={'V': np.ones(H.shape[1])}).fit(H).labels_
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
-    assert_equal(n_clusters_2, n_clusters)
+    assert(n_clusters_2 == n_clusters)
 
 
 def test_rsl_badargs():


### PR DESCRIPTION
Closes #448:
* Drop Python 3.5 support (scikit-learn requires at least 3.6)
* Fix bugs in tests (use of removed testing utilities from sklearn, warnings filter)