### PR TITLE
Update pyproject.toml to use oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = [
   "setuptools",
   "wheel",
   "cython",
-  "numpy"
+  "oldest-supported-numpy"
 ]


### PR DESCRIPTION
Use oldest-supported-numpy as build requirement to fix issue #457