### PR TITLE
Fix numpy 1.20 deprecation warnings

### DIFF
--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -200,7 +200,7 @@ cdef class BoruvkaUnionFind (object):
         self._rank_arr = np.zeros(size, dtype=np.uint8)
         self._rank = (<np.uint8_t[:size:1]> (<np.uint8_t *>
                                              self._rank_arr.data))
-        self.is_component = np.ones(size, dtype=np.bool)
+        self.is_component = np.ones(size, dtype=bool)
 
     cdef int union_(self, np.intp_t x, np.intp_t y) except -1:
         """Union together elements x and y"""

--- a/hdbscan/_hdbscan_tree.pyx
+++ b/hdbscan/_hdbscan_tree.pyx
@@ -91,7 +91,7 @@ cpdef np.ndarray condense_tree(np.ndarray[np.double_t, ndim=2] hierarchy,
     relabel = np.empty(root + 1, dtype=np.intp)
     relabel[root] = num_points
     result_list = []
-    ignore = np.zeros(len(node_list), dtype=np.int)
+    ignore = np.zeros(len(node_list), dtype=int)
 
     for node in node_list:
         if ignore[node] or node < num_points:
@@ -312,7 +312,7 @@ cdef class TreeUnionFind (object):
         self._data_arr.T[0] = np.arange(size)
         self._data = (<np.intp_t[:size, :2:1]> (
             <np.intp_t *> self._data_arr.data))
-        self.is_component = np.ones(size, dtype=np.bool)
+        self.is_component = np.ones(size, dtype=bool)
 
     cdef union_(self, np.intp_t x, np.intp_t y):
         cdef np.intp_t x_root = self.find(x)

--- a/hdbscan/flat.py
+++ b/hdbscan/flat.py
@@ -331,7 +331,7 @@ def approximate_predict_flat(clusterer,
         else:
             return labels, probabilities
 
-    labels = np.empty(points_to_predict.shape[0], dtype=np.int)
+    labels = np.empty(points_to_predict.shape[0], dtype=np.int32)
     probabilities = np.empty(points_to_predict.shape[0], dtype=np.float64)
 
     min_samples = clusterer.min_samples or clusterer.min_cluster_size

--- a/hdbscan/prediction.py
+++ b/hdbscan/prediction.py
@@ -385,7 +385,7 @@ def approximate_predict(clusterer, points_to_predict):
         probabilities = np.zeros(points_to_predict.shape[0], dtype=np.float32)
         return labels, probabilities
 
-    labels = np.empty(points_to_predict.shape[0], dtype=np.int)
+    labels = np.empty(points_to_predict.shape[0], dtype=np.int32)
     probabilities = np.empty(points_to_predict.shape[0], dtype=np.float64)
 
     min_samples = clusterer.min_samples or clusterer.min_cluster_size
@@ -465,7 +465,7 @@ def approximate_predict_scores(clusterer, points_to_predict):
         scores = np.ones(points_to_predict.shape[0], dtype=np.int32)
         return scores
 
-    scores = np.empty(points_to_predict.shape[0], dtype=np.float)
+    scores = np.empty(points_to_predict.shape[0], dtype=np.float64)
 
     min_samples = clusterer.min_samples or clusterer.min_cluster_size
     neighbor_distances, neighbor_indices = \


### PR DESCRIPTION
This PR tries to fix a set of deprecation warnings thrown when hdbscan runs with numpy 1.20:
```
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
```

Because of the way the test suite checks the warning stack, these deprecation warnings cause test failures against numpy==1.20

```
python3.8-hdbscan> E           AssertionError: assert False
python3.8-hdbscan> E            +  where False = issubclass(<class 'DeprecationWarning'>, UserWarning)
python3.8-hdbscan> E            +    where <class 'DeprecationWarning'> = <warnings.WarningMessage object at 0x7fffaa4ce880>.category
python3.8-hdbscan> test_flat.py:220: AssertionError
```