### PR TITLE
Incorrect initialization in BallTreeBoruvka dual_tree_traversal

### DIFF
--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -1285,6 +1285,9 @@ cdef class BallTreeBoruvkaAlgorithm (object):
 
             new_bound = 0.0
 
+            new_upper_bound = 0.0
+            new_lower_bound = DBL_MAX
+
             point_indices1 = self.idx_array[node1_info.idx_start:
                                             node1_info.idx_end]
             point_indices2 = self.idx_array[node2_info.idx_start:

--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -1283,8 +1283,6 @@ cdef class BallTreeBoruvkaAlgorithm (object):
         #       propagate the results up the tree.
         if node1_info.is_leaf and node2_info.is_leaf:
 
-            new_bound = 0.0
-
             new_upper_bound = 0.0
             new_lower_bound = DBL_MAX
 


### PR DESCRIPTION
Change the bound initialization to match that of the KDTreeBoruvka dual_tree_traversal.

This change makes the sum of the single_linkage_tree distances match those calculated using the generic algorithm for almost all cases.

It also eliminates a 'used variable before initialization' warning when compiling.