### PR TITLE
Remove usage of six

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -11,7 +11,6 @@ from sklearn.metrics import pairwise_distances
 from scipy.sparse import issparse
 from sklearn.neighbors import KDTree, BallTree
 from joblib import Memory
-import six
 from warnings import warn
 from sklearn.utils import check_array
 from joblib.parallel import cpu_count
@@ -719,7 +718,7 @@ def hdbscan(
         check_precomputed_distance_matrix(X)
 
     # Python 2 and 3 compliant string_type checking
-    if isinstance(memory, six.string_types):
+    if isinstance(memory, str):
         memory = Memory(cachedir=memory, verbose=0)
 
     size = X.shape[0]

--- a/hdbscan/robust_single_linkage_.py
+++ b/hdbscan/robust_single_linkage_.py
@@ -9,7 +9,6 @@ from sklearn.metrics import pairwise_distances
 from scipy.sparse import issparse
 
 from joblib import Memory
-import six
 from sklearn.utils import check_array
 
 from ._hdbscan_linkage import mst_linkage_core, mst_linkage_core_vector, label
@@ -239,7 +238,7 @@ def robust_single_linkage(X, cut, k=5, alpha=1.4142135623730951,
                              ' defined!')
 
     X = check_array(X, accept_sparse='csr')
-    if isinstance(memory, six.string_types):
+    if isinstance(memory, str):
         memory = Memory(cachedir=memory, verbose=0)
 
     if algorithm != 'best':

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy>=1.20
 scipy>= 1.0
 scikit-learn>=0.20
 joblib>=1.0
-six


### PR DESCRIPTION
This PR removes the usage of `six` from the package - mainly `six.string_types`. After the usage is removed, `six` is also removed from the requirements file.