### PR TITLE
hdbscan: add support to other types of input integers

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -674,7 +674,8 @@ def hdbscan(
     if min_samples is None:
         min_samples = min_cluster_size
 
-    if type(min_samples) is not int or type(min_cluster_size) is not int:
+    if not np.issubdtype(type(min_samples), np.integer) or \
+       not np.issubdtype(type(min_cluster_size), np.integer):
         raise ValueError("Min samples and min cluster size must be integers!")
 
     if min_samples <= 0 or min_cluster_size <= 0:
@@ -685,7 +686,7 @@ def hdbscan(
     if min_cluster_size == 1:
         raise ValueError("Min cluster size must be greater than one")
 
-    if type(cluster_selection_epsilon) is int:
+    if np.issubdtype(type(cluster_selection_epsilon), np.integer):
         cluster_selection_epsilon = float(cluster_selection_epsilon)
 
     if type(cluster_selection_epsilon) is not float or cluster_selection_epsilon < 0.0:


### PR DESCRIPTION
Both attributes like min_samples and min_cluster_size can be defined
using other types of integer like Numpy's int16, int32 and int64. This
should be also supported by HDBSCAN. This commit only extendes the check
to other types of integers.

For further example, you can test using:

```python
import numpy as np

a = 10
b = np.int16(10)
c = np.int64(10)

print(isinstance(a, int))
print(isinstance(b, int))
print(isinstance(c, int))
print(np.issubdtype(type(a), np.integer))
print(np.issubdtype(type(b), np.integer))
print(np.issubdtype(type(c), np.integer))
```
The output is:
```bash
True
False
False
True
True
True
```

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>