### PR TITLE
Add parameter to DBCV which toggles the usage of mutual reachability distances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ About this fork
 
 While writing my Bachelor's Thesis which includes a comparison of clustering 
 validity metrics like the one presented in 
-`this paper <https://www.semanticscholar.org/paper/Relative-clustering-validity-criteria%3A-A-overview-Vendramin-Campello/ad93d3b55fb94827c4df45e9fc67c55a7d90d00b>` 
+`this paper <https://www.semanticscholar.org/paper/Relative-clustering-validity-criteria%3A-A-overview-Vendramin-Campello/ad93d3b55fb94827c4df45e9fc67c55a7d90d00b>`_ 
 (but focused on the application of metrics on non-spherical/density-based clusters) 
 I noticed that DBCV might actually perform better if it just used euclidean distances 
 instead of mutual reachablity distances when constructing the minimum spanning trees. 

--- a/README.rst
+++ b/README.rst
@@ -26,18 +26,6 @@
     :target: https://mybinder.org/v2/gh/scikit-learn-contrib/hdbscan
     :alt: Launch example notebooks in Binder
 
-=======
-About this fork
-=======
-
-While writing my Bachelor's Thesis which includes a comparison of clustering 
-validity metrics like the one presented in 
-`this paper <https://www.semanticscholar.org/paper/Relative-clustering-validity-criteria%3A-A-overview-Vendramin-Campello/ad93d3b55fb94827c4df45e9fc67c55a7d90d00b>`_ 
-(but focused on the application of metrics on non-spherical/density-based clusters) 
-I noticed that DBCV might actually perform better if it just used euclidean distances 
-instead of mutual reachablity distances when constructing the minimum spanning trees. 
-This fork adds a parameter to the DBCV metric which toggles the usage of mutual reachability distances. 
-(the approach of the paper referenced above is also used in the DBCV paper)
 
 =======
 HDBSCAN

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,18 @@
     :target: https://mybinder.org/v2/gh/scikit-learn-contrib/hdbscan
     :alt: Launch example notebooks in Binder
 
+=======
+About this fork
+=======
+
+While writing my Bachelor's Thesis which includes a comparison of clustering 
+validity metrics like the one presented in 
+`this paper <https://www.semanticscholar.org/paper/Relative-clustering-validity-criteria%3A-A-overview-Vendramin-Campello/ad93d3b55fb94827c4df45e9fc67c55a7d90d00b>` 
+(but focused on the application of metrics on non-spherical/density-based clusters) 
+I noticed that DBCV might actually perform better if it just used euclidean distances 
+instead of mutual reachablity distances when constructing the minimum spanning trees. 
+This fork adds a parameter to the DBCV metric which toggles the usage of mutual reachability distances. 
+(the approach of the paper referenced above is also used in the DBCV paper)
 
 =======
 HDBSCAN

--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -312,7 +312,7 @@ def validity_index(X, labels, metric='euclidean',
 
     mst_raw_dist : optional, boolean (default False)
         If True, the MST's are constructed solely via 'raw' distances (depending on the given metric, e.g. euclidean distances)
-        instead of using mutual reachability distances. Thus, setting this parameter to True, avoids using 'all-points-core-distances' at all.
+        instead of using mutual reachability distances. Thus setting this parameter to True avoids using 'all-points-core-distances' at all.
         This is advantageous specifically in the case of elongated clusters that lie in close proximity to each other <citation needed>.
 
     **kwd_args :

--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -278,8 +278,7 @@ def density_separation(X, labels, cluster_id1, cluster_id2,
 
 
 def validity_index(X, labels, metric='euclidean',
-                    d=None, per_cluster_scores=False, print_validity_components=False,
-                    print_max_euclid_to_coredist_ratios=False, mst_euclid_only=False, **kwd_args):
+                    d=None, per_cluster_scores=False, mst_euclid_only=False, verbose=False,  **kwd_args):
     """
     Compute the density based cluster validity index for the
     clustering specified by `labels` and for each cluster in `labels`.
@@ -355,7 +354,7 @@ def validity_index(X, labels, metric='euclidean',
             metric,
             d,
             no_coredist=mst_euclid_only,
-            print_max_euclid_to_coredist_ratios=print_max_euclid_to_coredist_ratios,
+            print_max_euclid_to_coredist_ratios=verbose,
             **kwd_args
         )
 
@@ -398,7 +397,7 @@ def validity_index(X, labels, metric='euclidean',
             max(min_density_sep, density_sparseness[i])
         )
 
-        if print_validity_components:
+        if verbose:
             print("Minimum density separation: " + str(min_density_sep))
             print("Density sparseness: " + str(density_sparseness[i]))
 

--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -36,7 +36,7 @@ def all_points_core_distance(distance_matrix, d=2.0):
     return result
 
 
-def print_max_ratio(stacked_distances):
+def max_ratio(stacked_distances):
     max_ratio = 0
     for i in range(stacked_distances.shape[0]):
         for j in range(stacked_distances.shape[1]):
@@ -46,12 +46,12 @@ def print_max_ratio(stacked_distances):
                 continue
             max_ratio = coredist/dist
 
-    print("Max euclidean distance to coredistance ratio: " + str(max_ratio))
+    return max_ratio
 
 
 def distances_between_points(X, labels, cluster_id,
                                     metric='euclidean', d=None, no_coredist=False,
-                                    print_max_euclid_to_coredist_ratios=False, **kwd_args):
+                                    print_max_raw_to_coredist_ratio=False, **kwd_args):
     """
     Compute pairwise distances for all the points of a cluster.
 
@@ -123,8 +123,8 @@ def distances_between_points(X, labels, cluster_id,
         stacked_distances = np.dstack(
             [distance_matrix, core_dist_matrix, core_dist_matrix.T])
 
-        if print_max_euclid_to_coredist_ratios:
-            print_max_ratio(stacked_distances)
+        if print_max_raw_to_coredist_ratio:
+            print("Max raw distance to coredistance ratio: " + str(max_ratio(stacked_distances)))
 
         return stacked_distances.max(axis=-1), core_distances
 
@@ -359,7 +359,7 @@ def validity_index(X, labels, metric='euclidean',
             metric,
             d,
             no_coredist=mst_raw_dist,
-            print_max_euclid_to_coredist_ratios=verbose,
+            print_max_raw_to_coredist_ratio=verbose,
             **kwd_args
         )
 

--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -36,11 +36,24 @@ def all_points_core_distance(distance_matrix, d=2.0):
     return result
 
 
-def all_points_mutual_reachability(X, labels, cluster_id,
-                                   metric='euclidean', d=None, **kwd_args):
+def print_max_ratio(stacked_distances):
+    max_ratio = 0
+    for i in range(stacked_distances.shape[0]):
+        for j in range(stacked_distances.shape[1]):
+            dist = stacked_distances[i][j][0]
+            coredist = stacked_distances[i][j][1]
+            if dist == 0 or coredist/dist <= max_ratio:
+                continue
+            max_ratio = coredist/dist
+
+    print("Max euclidean distance to coredistance ratio: " + str(max_ratio))
+
+
+def distances_between_points(X, labels, cluster_id,
+                                    metric='euclidean', d=None, no_coredist=False,
+                                    print_max_euclid_to_coredist_ratios=False, **kwd_args):
     """
-    Compute the all-points-mutual-reachability distances for all the points of
-    a cluster.
+    Compute pairwise distances for all the points of a cluster.
 
     If metric is 'precomputed' then assume X is a distance matrix for the full
     dataset. Note that in this case you must pass in 'd' the dimension of the
@@ -58,9 +71,7 @@ def all_points_mutual_reachability(X, labels, cluster_id,
         cluster label to each data point, with -1 for noise points.
 
     cluster_id : integer
-        The cluster label for which to compute the all-points
-        mutual-reachability (which should be done on a cluster
-        by cluster basis).
+        The cluster label for which to compute the distances
 
     metric : string
         The metric used to compute distances for the clustering (and
@@ -80,9 +91,8 @@ def all_points_mutual_reachability(X, labels, cluster_id,
     Returns
     -------
 
-    mutual_reachaibility : array (n_samples, n_samples)
-        The pairwise mutual reachability distances between all points in `X`
-        with `label` equal to `cluster_id`.
+    distances : array (n_samples, n_samples)
+        The distances between all points in `X` with `label` equal to `cluster_id`.
 
     core_distances : array (n_samples,)
         The all-points-core_distance of all points in `X` with `label` equal
@@ -104,13 +114,19 @@ def all_points_mutual_reachability(X, labels, cluster_id,
                                              **kwd_args)
         d = X.shape[1]
 
-    core_distances = all_points_core_distance(distance_matrix.copy(), d=d)
-    core_dist_matrix = np.tile(core_distances, (core_distances.shape[0], 1))
+    if no_coredist:
+        return distance_matrix, None
 
-    result = np.dstack(
-        [distance_matrix, core_dist_matrix, core_dist_matrix.T]).max(axis=-1)
+    else:
+        core_distances = all_points_core_distance(distance_matrix.copy(), d=d)
+        core_dist_matrix = np.tile(core_distances, (core_distances.shape[0], 1))
+        stacked_distances = np.dstack(
+            [distance_matrix, core_dist_matrix, core_dist_matrix.T])
 
-    return result, core_distances
+        if print_max_euclid_to_coredist_ratios:
+            print_max_ratio(stacked_distances)
+
+        return stacked_distances.max(axis=-1), core_distances
 
 
 def internal_minimum_spanning_tree(mr_distances):
@@ -181,11 +197,10 @@ def internal_minimum_spanning_tree(mr_distances):
 def density_separation(X, labels, cluster_id1, cluster_id2,
                        internal_nodes1, internal_nodes2,
                        core_distances1, core_distances2,
-                       metric='euclidean', **kwd_args):
+                       metric='euclidean', no_coredist=False, **kwd_args):
     """
     Compute the density separation between two clusters. This is the minimum
-    all-points mutual reachability distance between pairs of points, one from
-    internal nodes of MSTs of each cluster.
+    distance between pairs of points, one from internal nodes of MSTs of each cluster.
 
     Parameters
     ----------
@@ -246,20 +261,25 @@ def density_separation(X, labels, cluster_id1, cluster_id2,
         cluster2 = X[labels == cluster_id2][internal_nodes2]
         distance_matrix = cdist(cluster1, cluster2, metric, **kwd_args)
 
-    core_dist_matrix1 = np.tile(core_distances1[internal_nodes1],
-                                (distance_matrix.shape[1], 1)).T
-    core_dist_matrix2 = np.tile(core_distances2[internal_nodes2],
-                                (distance_matrix.shape[0], 1))
+    if no_coredist:
+        return distance_matrix.min()
 
-    mr_dist_matrix = np.dstack([distance_matrix,
-                                core_dist_matrix1,
-                                core_dist_matrix2]).max(axis=-1)
+    else:
+        core_dist_matrix1 = np.tile(core_distances1[internal_nodes1],
+                                    (distance_matrix.shape[1], 1)).T
+        core_dist_matrix2 = np.tile(core_distances2[internal_nodes2],
+                                    (distance_matrix.shape[0], 1))
 
-    return mr_dist_matrix.min()
+        mr_dist_matrix = np.dstack([distance_matrix,
+                                    core_dist_matrix1,
+                                    core_dist_matrix2]).max(axis=-1)
+
+        return mr_dist_matrix.min()
 
 
 def validity_index(X, labels, metric='euclidean',
-                   d=None, per_cluster_scores=False, **kwd_args):
+                    d=None, per_cluster_scores=False, print_validity_components=False,
+                    print_max_euclid_to_coredist_ratios=False, mst_euclid_only=False, **kwd_args):
     """
     Compute the density based cluster validity index for the
     clustering specified by `labels` and for each cluster in `labels`.
@@ -327,18 +347,20 @@ def validity_index(X, labels, metric='euclidean',
         if np.sum(labels == cluster_id) == 0:
             continue
 
-        mr_distances, core_distances[
-            cluster_id] = all_points_mutual_reachability(
+        distances_for_mst, core_distances[
+            cluster_id] = distances_between_points(
             X,
             labels,
             cluster_id,
             metric,
             d,
+            no_coredist=mst_euclid_only,
+            print_max_euclid_to_coredist_ratios=print_max_euclid_to_coredist_ratios,
             **kwd_args
         )
 
         mst_nodes[cluster_id], mst_edges[cluster_id] = \
-            internal_minimum_spanning_tree(mr_distances)
+            internal_minimum_spanning_tree(distances_for_mst)
         density_sparseness[cluster_id] = mst_edges[cluster_id].T[2].max()
 
     for i in range(max_cluster_id):
@@ -357,7 +379,8 @@ def validity_index(X, labels, metric='euclidean',
                 X, labels, i, j,
                 internal_nodes_i, internal_nodes_j,
                 core_distances[i], core_distances[j],
-                metric=metric, **kwd_args
+                metric=metric, no_coredist=mst_euclid_only,
+                **kwd_args
             )
             density_sep[j, i] = density_sep[i, j]
 
@@ -374,6 +397,11 @@ def validity_index(X, labels, metric='euclidean',
             (min_density_sep - density_sparseness[i]) /
             max(min_density_sep, density_sparseness[i])
         )
+
+        if print_validity_components:
+            print("Minimum density separation: " + str(min_density_sep))
+            print("Density sparseness: " + str(density_sparseness[i]))
+
         cluster_size = np.sum(labels == i)
         result += (cluster_size / n_samples) * cluster_validity_indices[i]
 

--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -278,7 +278,7 @@ def density_separation(X, labels, cluster_id1, cluster_id2,
 
 
 def validity_index(X, labels, metric='euclidean',
-                    d=None, per_cluster_scores=False, mst_euclid_only=False, verbose=False,  **kwd_args):
+                    d=None, per_cluster_scores=False, mst_raw_dist=False, verbose=False,  **kwd_args):
     """
     Compute the density based cluster validity index for the
     clustering specified by `labels` and for each cluster in `labels`.
@@ -309,6 +309,11 @@ def validity_index(X, labels, metric='euclidean',
         Whether to return the validity index for individual clusters.
         Defaults to False with the function returning a single float
         value for the whole clustering.
+
+    mst_raw_dist : optional, boolean (default False)
+        If True, the MST's are constructed solely via 'raw' distances (depending on the given metric, e.g. euclidean distances)
+        instead of using mutual reachability distances. Thus, setting this parameter to True, avoids using 'all-points-core-distances' at all.
+        This is advantageous specifically in the case of elongated clusters that lie in close proximity to each other <citation needed>.
 
     **kwd_args :
         Extra arguments to pass to the distance computation for other
@@ -353,7 +358,7 @@ def validity_index(X, labels, metric='euclidean',
             cluster_id,
             metric,
             d,
-            no_coredist=mst_euclid_only,
+            no_coredist=mst_raw_dist,
             print_max_euclid_to_coredist_ratios=verbose,
             **kwd_args
         )
@@ -378,7 +383,7 @@ def validity_index(X, labels, metric='euclidean',
                 X, labels, i, j,
                 internal_nodes_i, internal_nodes_j,
                 core_distances[i], core_distances[j],
-                metric=metric, no_coredist=mst_euclid_only,
+                metric=metric, no_coredist=mst_raw_dist,
                 **kwd_args
             )
             density_sep[j, i] = density_sep[i, j]


### PR DESCRIPTION
While writing my Bachelor's Thesis which includes a comparison of clustering validity metrics like the one presented in [this paper](https://www.semanticscholar.org/paper/Relative-clustering-validity-criteria%3A-A-overview-Vendramin-Campello/ad93d3b55fb94827c4df45e9fc67c55a7d90d00b) (but focused on the application of metrics on non-spherical/density-based clusters) I noticed that DBCV actually performs better (according to my benchmarks, which only account for clusters with points that are normally distributed and lie relatively close to each other, especially in the case of non-spherical clusters) if it just used euclidean distances instead of mutual reachability distances when constructing the minimum spanning trees.
  
(the approach of the paper referenced above is also used in the DBCV paper for comparing DBCV to existing metrics)
  
For example, after reading the paper [defining DBCV](https://www.dbs.ifi.lmu.de/~zimek/publications/SDM2014/DBCV.pdf) I would expect DBCV to assign a relatively high score to the clustering depicted below. In contrast, metrics using a definition of clusters that implicitly assumes spherical clusters like the Silhouette Coefficient would assign a score that is relatively low to the clustering, even though it is arguably the "correct" clustering. The reason for that is that points that lie roughly in the marked areas are closer to the other cluster-center than the one they were assigned to.
  
Indeed, the Silhouette Coefficient does not perform well when applied to datasets with points that are distributed in similar ways to the ones in the picture below. (using the definition of bad performance as stated in the referenced papers — with clusterings more similar to the ideal clustering receiving worse scores)
  
However, the default version of DBCV which uses the mutual reachability distances for the construction of the trees performs basically just as bad.
  
![grafik](https://user-images.githubusercontent.com/72552948/175496195-fa42d18e-ff18-4dd1-b4ea-3df11e6c88fe.png)
  
Because DBCV was not performing the way one would expect it I added code to emit the values of the components that are used to calculate the score. The cause for the bad scores were the `all_points_core_distance`s surpassing the euclidean distances between the pairs of points by far (up to 18-fold) even though the paper states that the euclidean distance between a pair of points and their core distances should be comparable.
  
[The code I used to calculate the ratios between the euclidean distances and the core-distances](https://github.com/luis261/hdbscan/blob/master/hdbscan/validity.py#L39)
  
This inflation of the core distances in the case of elongated clusters leads to long distances in the constructed minimum spanning trees which lead to worse scores.
  
My fork adds a parameter to the DBCV metric included in this implementation of HDBSCAN (the validity module) which toggles the usage of mutual reachability distances.
  
I included my modified version of DBCV (with the new parameter set so core-distances are not used) in my benchmark as well and it outperformed the default version by far.
  
Here is a link to the benchmarking code: https://github.com/luis261/clustering-validity-comparison
  
I would really appreciate someone else's opinion on this as I'm not sure if I should approach the authors of the DBCV paper regarding my finding. Maybe someone could even have a look at my benchmarking code and my modifications of the DBCV metric as well as the original code in the validity module to make sure my finding is not just caused by a bug.
  
PS: there are links in my thesis to my fork of HDBSCAN. I am not sure how it works, but in case this actually gets merged it would be important to me that my fork does not get deleted as a result of the merge, so the links in my thesis stay valid.