### PR TITLE
Fixed: validity index no longer returning nan

### DIFF
--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -31,7 +31,11 @@ def all_points_core_distance(distance_matrix, d=2.0):
         distance_matrix != 0]) ** d
     result = distance_matrix.sum(axis=1)
     result /= distance_matrix.shape[0] - 1
-    result **= (-1.0 / d)
+
+    if result.sum() == 0:
+        result = np.zeros(len(distance_matrix))
+    else:
+        result **= (-1.0 / d)
 
     return result
 


### PR DESCRIPTION
Previously, `all_points_core_distance` would return NaN if all points within a cluster had a distance of zero to one another, i.e. were all the same. Now, if this case occurs, it returns an array of zeros with length `len(distance_matrix)`.

This PR is based on [this issue](https://github.com/scikit-learn-contrib/hdbscan/issues/127). 