### PR TITLE
Use a positional argument for the cachedir/location

### DIFF
--- a/docs/basic_hdbscan.rst
+++ b/docs/basic_hdbscan.rst
@@ -146,7 +146,7 @@ want do some method chaining.
 .. parsed-literal::
 
     HDBSCAN(algorithm='best', alpha=1.0, approx_min_span_tree=True,
-        gen_min_span_tree=False, leaf_size=40, memory=Memory(cachedir=None),
+        gen_min_span_tree=False, leaf_size=40, memory=Memory(None),
         metric='euclidean', min_cluster_size=5, min_samples=None, p=None)
 
 

--- a/docs/how_hdbscan_works.rst
+++ b/docs/how_hdbscan_works.rst
@@ -71,7 +71,7 @@ library <https://github.com/scikit-learn-contrib/hdbscan>`__ and get to work.
 .. parsed-literal::
 
     HDBSCAN(algorithm='best', alpha=1.0, approx_min_span_tree=True,
-        gen_min_span_tree=True, leaf_size=40, memory=Memory(cachedir=None),
+        gen_min_span_tree=True, leaf_size=40, memory=Memory(None),
         metric='euclidean', min_cluster_size=5, min_samples=None, p=None)
 
 

--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -506,7 +506,7 @@ def hdbscan(
     p=2,
     leaf_size=40,
     algorithm="best",
-    memory=Memory(cachedir=None, verbose=0),
+    memory=Memory(None, verbose=0),
     approx_min_span_tree=True,
     gen_min_span_tree=False,
     core_dist_n_jobs=4,
@@ -726,7 +726,7 @@ def hdbscan(
 
     # Python 2 and 3 compliant string_type checking
     if isinstance(memory, str):
-        memory = Memory(cachedir=memory, verbose=0)
+        memory = Memory(memory, verbose=0)
 
     size = X.shape[0]
     min_samples = min(size - 1, min_samples)
@@ -1093,7 +1093,7 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
         p=None,
         algorithm="best",
         leaf_size=40,
-        memory=Memory(cachedir=None, verbose=0),
+        memory=Memory(None, verbose=0),
         approx_min_span_tree=True,
         gen_min_span_tree=False,
         core_dist_n_jobs=4,

--- a/hdbscan/robust_single_linkage_.py
+++ b/hdbscan/robust_single_linkage_.py
@@ -135,7 +135,7 @@ def _rsl_boruvka_balltree(X, k=5, alpha=1.0,
 
 def robust_single_linkage(X, cut, k=5, alpha=1.4142135623730951,
                           gamma=5, metric='euclidean', algorithm='best',
-                          memory=Memory(cachedir=None, verbose=0), leaf_size=40,
+                          memory=Memory(None, verbose=0), leaf_size=40,
                           core_dist_n_jobs=4, **kwargs):
     """Perform robust single linkage clustering from a vector array
     or distance matrix.
@@ -239,7 +239,7 @@ def robust_single_linkage(X, cut, k=5, alpha=1.4142135623730951,
 
     X = check_array(X, accept_sparse='csr')
     if isinstance(memory, str):
-        memory = Memory(cachedir=memory, verbose=0)
+        memory = Memory(memory, verbose=0)
 
     if algorithm != 'best':
         if algorithm == 'generic':


### PR DESCRIPTION
The goal is to fix issue #562 by simply calling the joblib ``Memory`` class with a positional argument instead of explciitly using the (now deprecated) keyword name ``cachedir``.