### PR TITLE
Bumped hdbscan version to `0.8.29`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def requirements():
 
 configuration = {
     'name': 'hdbscan',
-    'version': '0.8.28',
+    'version': '0.8.29',
     'description': 'Clustering based on density with variable density clusters',
     'long_description': readme(),
     'classifiers': [


### PR DESCRIPTION
Hi hdbscan maintainer(s),


This PR would prepare for the release to PyPi. I also notice that README.md contains old documentation on how to run tests. I believe this package no longer use `nose` in favor of `pytest`.

I had to add the following line before running pytest, but it can be in a separate PR.

```diff
diff --git a/hdbscan/hdbscan_.py b/hdbscan/hdbscan_.py
index ce0092d..7daed80 100644
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -17,6 +17,10 @@ from joblib.parallel import cpu_count
 
 from scipy.sparse import csgraph
 
+import numpy
+import pyximport
+pyximport.install(setup_args={"include_dirs":numpy.get_include()})
+
```

I think there is a remaining action item from maintainer: launch a new Github Workflow to a new release.

Please let me know if there is something I can help with.

Regards,
Dat 

