### PR TITLE
Update requirements.txt with joblib<1.2 to solve #565

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cython>=0.27
 numpy>=1.20
 scipy>= 1.0
 scikit-learn>=0.20
-joblib>=1.0
+joblib>=1.0,<1.2


### PR DESCRIPTION
Hi, I'm a BuildNN developer and data scientist. While using HDBSCAN, I encountered issue #565 due to the minor update in `joblib=1.2` that does not ensure retrocompatibility. I solved the problem specifying the joblib version to be lower than 1.2.