### PR TITLE
Update validity.py

### DIFF
--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -175,6 +175,8 @@ def internal_minimum_spanning_tree(mr_distances):
 
     vertices = np.arange(mr_distances.shape[0])[
         np.bincount(min_span_tree.T[:2].flatten().astype(np.intp)) > 1]
+    if not len(vertices):
+        vertices = [0]
     # A little "fancy" we select from the flattened array reshape back
     # (Fortran format to get indexing right) and take the product to do an and
     # then convert back to boolean type.


### PR DESCRIPTION
Adding a couple of lines to set vertices = [0] if vertices is empty. This issue occurs in the edge cases when cluster size = 2, and causes a ValueError due to zero-size array.

Fixes errors similar to #576 