### PR TITLE
Shield against breaking changes from scikit-learn 1.3.0 release

### DIFF
--- a/hdbscan/robust_single_linkage_.py
+++ b/hdbscan/robust_single_linkage_.py
@@ -2,8 +2,10 @@
 """
 Robust Single Linkage: Density based single linkage clustering.
 """
+import sklearn
 import numpy as np
 
+from packaging.version import Version
 from sklearn.base import BaseEstimator, ClusterMixin
 from sklearn.metrics import pairwise_distances
 from scipy.sparse import issparse
@@ -24,7 +26,14 @@ from warnings import warn
 #
 # License: BSD 3 clause
 
-FAST_METRICS = KDTree.valid_metrics + BallTree.valid_metrics
+if Version(sklearn.__version__) >= Version("1.3.0"):
+    kdtree_valid_metrics = KDTree.valid_metrics()
+    balltree_valid_metrics = BallTree.valid_metrics()
+else:
+    kdtree_valid_metrics = KDTree.valid_metrics
+    balltree_valid_metrics = BallTree.valid_metrics
+
+FAST_METRICS = kdtree_valid_metrics + balltree_valid_metrics
 
 
 def _rsl_generic(X, k=5, alpha=1.4142135623730951, metric='euclidean',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cython>=0.27
 numpy>=1.20
+packaging
 scipy>= 1.0
 scikit-learn>=0.20
 joblib>=1.0


### PR DESCRIPTION
This PR is a possible fix for https://github.com/scikit-learn-contrib/hdbscan/issues/597 - following the approach taken in https://github.com/scikit-learn/scikit-learn/issues/26742

It replaces all references to the `KDTree` and `BallTree` `.valid_metrics` attribute (which is not available anymore since `scikit-learn==1.3.0`) with calls to the new equivalent `.valid_metrics()` method:

```python
# scikit-learn==1.3.0
>>> from sklearn.neighbors import KDTree, BallTree
>>> KDTree.valid_metrics()
['euclidean', 'l2', 'minkowski', 'p', 'manhattan', 'cityblock', 'l1', 'chebyshev', 'infinity']
>>> BallTree.valid_metrics()
['euclidean', 'l2', 'minkowski', 'p', 'manhattan', 'cityblock', 'l1', 'chebyshev', 'infinity', 'seuclidean', 'mahalanobis', 'hamming', 'canberra', 'braycurtis', 'jaccard', 'dice', 'rogerstanimoto', 'russellrao', 'sokalmichener', 'sokalsneath', 'haversine', 'pyfunc']
```

```python
# scikit-learn<1.3.0
>>> from sklearn.neighbors import KDTree, BallTree
>>> KDTree.valid_metrics
['euclidean', 'l2', 'minkowski', 'p', 'manhattan', 'cityblock', 'l1', 'chebyshev', 'infinity']
>>> BallTree.valid_metrics
['euclidean', 'l2', 'minkowski', 'p', 'manhattan', 'cityblock', 'l1', 'chebyshev', 'infinity', 'seuclidean', 'mahalanobis', 'wminkowski', 'hamming', 'canberra', 'braycurtis', 'matching', 'jaccard', 'dice', 'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener', 'sokalsneath', 'haversine', 'pyfunc']
```

As suggested in https://github.com/scikit-learn-contrib/hdbscan/issues/597, another completely valid approach would be to hard-code the lists of acceptable metric names instead 🙌 