### PR TITLE
Wheel publish github action

### DIFF
--- a/.github/workflows/pythonpublish_wheel.yml
+++ b/.github/workflows/pythonpublish_wheel.yml
@@ -1,0 +1,64 @@
+name: Upload Python Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: "The branch, tag or SHA to checkout."
+        required: true
+        default: "master"
+
+jobs:
+  linux-deploy:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+    strategy:
+      matrix:
+        python: ["cp38-cp38", "cp39-cp39", "cp310-cp310", "cp311-cp311"]
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          ref: ${{ inputs.checkout_ref }}
+      - name: Build wheel
+        env:
+          PYTHON: /opt/python/${{ matrix.python }}/bin/python
+        run: |
+          $PYTHON -m pip install "cython<3" oldest-supported-numpy
+          $PYTHON -m build --no-isolation
+          auditwheel repair dist/*linux_x86_64.whl
+      - name: Publish to pypi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pipx install twine
+          twine upload dist/*.tar.gz --skip-existing
+          twine upload wheelhouse/*.whl --skip-existing
+  other-deploy:
+    strategy:
+      matrix:
+        python: ["3.8", "3.9", "3.10", "3.11"]
+        os: [windows-2019, macos-11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          ref: ${{ inputs.checkout_ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools build wheel twine
+          pip install "cython<3" oldest-supported-numpy
+      - name: Build wheel
+        run: |
+          python -m build --no-isolation
+      - name: Publish to pypi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload dist/*.whl --skip-existing


### PR DESCRIPTION
In light of the recent issues caused by compilation not working in various environments, I've created a github action to create and publish wheels for all operating systems and currently supported python versions.
![image](https://github.com/scikit-learn-contrib/hdbscan/assets/63673016/d3f51bb1-3a0f-458f-ad12-40d92e82e2c1)

The current publish job fails to upload a wheel because it's not compliant with the manylinux standards and PyPi won't accept distribution specific wheels. To get around this, I used the pypa official container for manylinux builds
![image](https://github.com/scikit-learn-contrib/hdbscan/assets/63673016/38272966-0a9c-4b18-9153-cea22ef2f6bd)

For windows and osx the job is a copy of the other existing one, with the added matrix strategy to cover the combinations.
![image](https://github.com/scikit-learn-contrib/hdbscan/assets/63673016/7fc224eb-4a19-4bf7-916c-76d5d74c39ee)
![image](https://github.com/scikit-learn-contrib/hdbscan/assets/63673016/d2a4eeac-3b57-4114-9bd5-44cd698317d0)

The wheels are created using non-isolated builds, so build requirements can be pinned if needed.
It is currently set to skip existing uploads in pypi, otherwise each job after the first one will report a failure just because the source distribution is already present in PyPi.

Trigger is manual and it takes a git ref to checkout as a parameter (default to master). This allows to execute the workflow on older versions and publish the resulting wheels.
Twine upload was not tested as I assume it will  fail due to missing permissions on the hdbscan project from my side. It's copy-pasted from the other action actions on the repo so it should be problematic