### PR TITLE
Build platform dependent wheel files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,149 +1,229 @@
-# Python package
-# Create and test a Python package on multiple Python versions.
-# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/python
-
+# Trigger a build when there is a push to the main branch or a tag starts with release-
 trigger:
-- master
+  branches:
+    include:
+    - master
+  tags:
+    include:
+    - release-*
 
-jobs:
-  - job: Linux
-    pool:
-      vmImage: ubuntu-latest
-    strategy:
-      matrix:
-        Python37:
-          python.version: '3.7'
-        Python38:
-          python.version: '3.8'
-        Python39:
-          python.version: '3.9'
+# Trigger a build when there is a pull request to the main branch
+# Ignore PRs that are just updating the docs
+pr:
+  branches:
+    include:
+    - master
+    exclude:
+    - doc/*
+    - README.rst
 
-    steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '$(python.version)'
-        displayName: 'Use Python $(python.version)'
+variables:
+  triggeredByPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
 
-      - script: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
+stages:
+  - stage: RunAllTests
+    displayName: Run test suite
+    jobs:
+      - job: run_platform_tests
+        strategy:
+          matrix:
+            mac_py37:
+              imageName: 'macOS-latest'
+              python.version: '3.7'
+            linux_py37:
+              imageName: 'ubuntu-latest'
+              python.version: '3.7'
+            windows_py37:
+              imageName: 'windows-latest'
+              python.version: '3.7'            
+            mac_py38:
+              imageName: 'macOS-latest'
+              python.version: '3.8'
+            linux_py38:
+              imageName: 'ubuntu-latest'
+              python.version: '3.8'
+            windows_py38:
+              imageName: 'windows-latest'
+              python.version: '3.8'
+            mac_py39:
+              imageName: 'macOS-latest'
+              python.version: '3.9'
+            linux_py39:
+              imageName: 'ubuntu-latest'
+              python.version: '3.9'
+            windows_py39:
+              imageName: 'windows-latest'
+              python.version: '3.9'
+            mac_py310:
+              imageName: 'macOS-latest'
+              python.version: '3.10'
+            linux_py310:
+              imageName: 'ubuntu-latest'
+              python.version: '3.10'
+            windows_py310:
+              imageName: 'windows-latest'
+              python.version: '3.10'
 
-      - script: |
-          pip install cython
-          python setup.py develop
+        pool:
+          vmImage: $(imageName)
 
-      - script: |
-          pip install pytest pytest-azurepipelines
-          pytest
-        displayName: 'pytest'
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Python $(python.version)'
 
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFiles: 'pytest.xml'
-          testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
-        condition: succeededOrFailed()
+        - script: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+          displayName: 'Install dependencies'
 
-  - job: Windows
-    pool:
-      vmImage: 'windows-latest'
-    strategy:
-      matrix:
-        Python37:
-          python.version: '3.7'
-        Python38:
-          python.version: '3.8'
-        Python39:
-          python.version: '3.9'
+        - script: |
+            pip install -e .
+            pip install pytest pytest-azurepipelines
+            pip install pytest-cov
+            pip install coveralls
+          displayName: 'Install package'
 
-    steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '$(python.version)'
-        displayName: 'Use Python $(python.version)'
+        - script: |
+            pytest hdbscan/tests --show-capture=no -v --disable-warnings --junitxml=junit/test-results.xml --cov=hdbscan/ --cov-report=xml --cov-report=html
+          displayName: 'Run tests'
 
-      - script: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
+        - bash: |
+            coveralls
+          displayName: 'Publish to coveralls'
+          condition: and(succeeded(), eq(variables.triggeredByPullRequest, false)) # Don't run this for PRs because they can't access pipeline secrets
+          env:
+            COVERALLS_REPO_TOKEN: $(COVERALLS_TOKEN)
 
-      - script: |
-          pip install cython
-          python setup.py develop
+        - task: PublishTestResults@2
+          inputs:
+            testResultsFiles: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+            testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
+          condition: succeededOrFailed()
 
-      - script: |
-          pip install pytest pytest-azurepipelines
-          pytest
-        displayName: 'pytest'
+  - stage: BuildPublishArtifact
+    dependsOn: RunAllTests
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/release-'), eq(variables.triggeredByPullRequest, false))
+    jobs:
+      # Need to use manylinux as ubuntu-latest is too new
+      - job: Manylinux2014Build
+        pool:
+          vmImage: 'ubuntu-latest'
+        container: quay.io/pypa/manylinux2014_x86_64:latest
+        strategy:
+          matrix:
+            linux_py37:
+              python.version: 'cp37-cp37m'
+            linux_py38:
+              python.version: 'cp38-cp38'
+            linux_py39:
+              python.version: 'cp39-cp39'
+            linux_py310:
+              python.version: 'cp310-cp310'
+        steps:
+        - script: |
+            "${PYBIN}/python" -m pip install --upgrade pip
+            "${PYBIN}/python" -m pip install wheel
+            "${PYBIN}/python" -m pip install -r requirements.txt
+          displayName: 'Install dependencies and build tools'
+          env:
+            PYBIN: /opt/python/$(python.version)/bin
+        - script: |
+            "${PYBIN}/python" setup.py sdist bdist_wheel
+          displayName: 'Build wheels'
+          env:
+            PYBIN: /opt/python/$(python.version)/bin
+        - bash: |
+            auditwheel repair dist/*linux_x86_64.whl --plat manylinux2014_x86_64 -w wheelhouse-manylinux/
+          displayName: 'Audit wheels'
+        
+        # - task: DownloadSecureFile@1
+        #   name: PYPIRC_CONFIG
+        #   displayName: 'Download pypirc'
+        #   inputs:
+        #     secureFile: 'pypirc'  
+        
+        # - bash: |
+        #     "${PYBIN}/python" -m pip install twine
+        #     "${PYBIN}/python" -m twine upload -r testpypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing --disable-progress-bar wheelhouse-manylinux/*
+        #     "${PYBIN}/python" -m twine upload -r testpypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing --disable-progress-bar dist/*.tar.gz
+        #   displayName: 'Publish wheel to PyPi'
+        #   env:
+        #     PYBIN: /opt/python/$(python.version)/bin
 
-  - job: MacOS
-    pool:
-      vmImage: 'macos-latest'
-    strategy:
-      matrix:
-        Python37:
-          python.version: '3.7'
-        Python38:
-          python.version: '3.8'
-        Python39:
-          python.version: '3.9'
+      - job: BuildWindowsAndMacOSArtifacts
+        displayName: Build source dists and wheels for windows and macOS
+        strategy:
+          matrix:
+            mac_py37:
+              imageName: 'macOS-latest'
+              python.version: '3.7'
+            windows_py37:
+              imageName: 'windows-latest'
+              python.version: '3.7'            
+            mac_py38:
+              imageName: 'macOS-latest'
+              python.version: '3.8'
+            windows_py38:
+              imageName: 'windows-latest'
+              python.version: '3.8'
+            mac_py39:
+              imageName: 'macOS-latest'
+              python.version: '3.9'
+            windows_py39:
+              imageName: 'windows-latest'
+              python.version: '3.9'
+            mac_py310:
+              imageName: 'macOS-latest'
+              python.version: '3.10'
+            windows_py310:
+              imageName: 'windows-latest'
+              python.version: '3.10'
 
-    steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '$(python.version)'
-        displayName: 'Use Python $(python.version)'
+        pool:
+          vmImage: $(imageName) 
 
-      - script: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Python $(python.version)'
 
-      - script: |
-          pip install cython
-          python setup.py develop
+        - script: |
+            python -m pip install --upgrade pip
+            pip install wheel
+            pip install -r requirements.txt
+          displayName: 'Install dependencies'
 
-      - script: |
-          pip install pytest pytest-azurepipelines
-          pytest
-        displayName: 'pytest'
+        - script: |
+            pip install -e .
+          displayName: 'Install package locally'
+        
+        - bash: |
+            python setup.py sdist bdist_wheel
+          displayName: 'Build package'
 
-  - job: Coverage
-    pool:
-      vmImage: ubuntu-latest
-    strategy:
-      matrix:
-        Python39:
-          python.version: '3.9'
+        - bash: |
+            export PACKAGE_VERSION="$(python setup.py --version)"
+            echo "Package Version: ${PACKAGE_VERSION}"
+            echo "##vso[task.setvariable variable=packageVersionFormatted;]release-${PACKAGE_VERSION}"
+          displayName: 'Get package version'
 
-    steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '$(python.version)'
-        displayName: 'Use Python $(python.version)'
+        - script: |
+            echo "Version in git tag $(Build.SourceBranchName) does not match version derived from setup.py $(packageVersionFormatted)"
+            exit 1
+          displayName: Raise error if version doesnt match tag
+          condition: and(succeeded(), ne(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))
 
-      - script: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        displayName: 'Install dependencies'
+        # - task: DownloadSecureFile@1
+        #   name: PYPIRC_CONFIG
+        #   displayName: 'Download pypirc'
+        #   inputs:
+        #     secureFile: 'pypirc'  
 
-      - script: |
-          pip install cython
-          pip install pytest
-          pip install pytest-cov
-          pip install coveralls
-          pip install codecov
-          python setup.py develop
-
-      - script: |
-          pip install pytest pytest-azurepipelines
-          pytest hdbscan/tests --show-capture=no -v --disable-warnings --junitxml=pytest.xml --cov=hdbscan/ --cov-report=xml --cov-report=html
-          codecov
-        displayName: 'pytest'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFiles: 'pytest.xml'
-          testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
-        condition: succeededOrFailed()
+        # - script: |
+        #     pip install twine
+        #     twine upload -r testpypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing  dist/* 
+        #   displayName: 'Upload to PyPI'
+        #   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,19 +138,19 @@ stages:
             auditwheel repair dist/*linux_x86_64.whl --plat manylinux2014_x86_64 -w wheelhouse-manylinux/
           displayName: 'Audit wheels'
         
-        # - task: DownloadSecureFile@1
-        #   name: PYPIRC_CONFIG
-        #   displayName: 'Download pypirc'
-        #   inputs:
-        #     secureFile: 'pypirc'  
+        - task: DownloadSecureFile@1
+          name: PYPIRC_CONFIG
+          displayName: 'Download pypirc'
+          inputs:
+            secureFile: 'pypirc'  
         
-        # - bash: |
-        #     "${PYBIN}/python" -m pip install twine
-        #     "${PYBIN}/python" -m twine upload -r testpypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing --disable-progress-bar wheelhouse-manylinux/*
-        #     "${PYBIN}/python" -m twine upload -r testpypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing --disable-progress-bar dist/*.tar.gz
-        #   displayName: 'Publish wheel to PyPi'
-        #   env:
-        #     PYBIN: /opt/python/$(python.version)/bin
+        - bash: |
+            "${PYBIN}/python" -m pip install twine
+            "${PYBIN}/python" -m twine upload -r pypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing --disable-progress-bar wheelhouse-manylinux/*
+            "${PYBIN}/python" -m twine upload -r pypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing --disable-progress-bar dist/*.tar.gz
+          displayName: 'Publish wheel to PyPi'
+          env:
+            PYBIN: /opt/python/$(python.version)/bin
 
       - job: BuildWindowsAndMacOSArtifacts
         displayName: Build source dists and wheels for windows and macOS
@@ -216,14 +216,14 @@ stages:
           displayName: Raise error if version doesnt match tag
           condition: and(succeeded(), ne(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))
 
-        # - task: DownloadSecureFile@1
-        #   name: PYPIRC_CONFIG
-        #   displayName: 'Download pypirc'
-        #   inputs:
-        #     secureFile: 'pypirc'  
+        - task: DownloadSecureFile@1
+          name: PYPIRC_CONFIG
+          displayName: 'Download pypirc'
+          inputs:
+            secureFile: 'pypirc'  
 
-        # - script: |
-        #     pip install twine
-        #     twine upload -r testpypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing  dist/* 
-        #   displayName: 'Upload to PyPI'
-        #   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))
+        - script: |
+            pip install twine
+            twine upload -r pypi --config-file $(PYPIRC_CONFIG.secureFilePath) --skip-existing  dist/* 
+          displayName: 'Upload to PyPI'
+          condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables['packageVersionFormatted']))


### PR DESCRIPTION
The checks are going to fail due to the lack of coveralls token secret. This will be fixed when we migrate devops organizations.