### PR TITLE
Fixed DeprecationWarning in hdbscan/hdbscan_.py

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -494,9 +494,9 @@ def remap_single_linkage_tree(tree, internal_to_raw, outliers):
 def is_finite(matrix):
     """Returns true only if all the values of a ndarray or sparse matrix are finite"""
     if issparse(matrix):
-        return np.alltrue(np.isfinite(matrix.tocoo().data))
+        return np.all(np.isfinite(matrix.tocoo().data))
     else:
-        return np.alltrue(np.isfinite(matrix))
+        return np.all(np.isfinite(matrix))
 
 
 def get_finite_row_indices(matrix):


### PR DESCRIPTION
Fixes ```DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.```