### PR TITLE
Add __version__ support

### DIFF
--- a/hdbscan/__init__.py
+++ b/hdbscan/__init__.py
@@ -5,5 +5,6 @@ from .prediction import (approximate_predict,
                          membership_vector,
                          all_points_membership_vectors,
                          approximate_predict_scores)
+from .version import VERSION
 
-
+__version__ = VERSION

--- a/hdbscan/version.py
+++ b/hdbscan/version.py
@@ -1,0 +1,4 @@
+""" This file contains the current version of the hdbscan package."""
+
+# This version constant will be used for hdbscan.__version__ and in setup.py file.
+VERSION = '0.8.33'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import warnings
+from hdbscan.version import VERSION
 
 try:
     from Cython.Distutils import build_ext
@@ -51,7 +52,7 @@ def requirements():
 
 configuration = {
     'name': 'hdbscan',
-    'version': '0.8.33',
+    'version': VERSION,
     'description': 'Clustering based on density with variable density clusters',
     'long_description': readme(),
     'classifiers': [


### PR DESCRIPTION
**Summary:**
I have made the following changes to improve version management in the `hdbscan` project:

- Created a new file named `version.py` in the `hdbscan` folder.
- Defined a constant `VERSION` within `version.py` to store the version of the package.
- Updated the version management approach to use `version.py` for version information.

**Details:**
In the past, the version of the `hdbscan` package used to be updated directly in the `setup.py` file. With these changes, we now store the version in the `version.py` file, which is accessible in both the `__init__.py` and `setup.py` files. This approach follows the common Python practice of managing the version in a dedicated file for improved consistency and ease of access.

**Expected Behavior:**
After this change, the version of the `hdbscan` package can be consistently accessed from `version.py` and can be easily imported into other parts of the project, including the `__init__.py` and `setup.py` files. Users can now access the package version using `hdbscan.__version__`.

