### PR TITLE
Remove cython from install requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cython>=0.27,<3
 numpy>=1.20
 scipy>= 1.0
 scikit-learn>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.20,<2
+numpy>=1.20,<3
 scipy>= 1.0
 scikit-learn>=0.20
 joblib>=1.0


### PR DESCRIPTION
Cython is a build-only dependency, so this PR removes Cython from the `install_requires` list of the hdbscan package.

[setup.py reads requirements.txt](https://github.com/scikit-learn-contrib/hdbscan/blob/master/setup.py#L78) to populate its runtime requirements, and [requirements.txt incldues cython](https://github.com/scikit-learn-contrib/hdbscan/blob/master/requirements.txt). So removing it from `requirements.txt` should be sufficient to fix this.

I can make a separate `requirements-build.txt` if the maintainers prefer using a requirements file for build dependencies.
