### PR TITLE
Support p values other than 2 for minkowski

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -250,10 +250,12 @@ def _hdbscan_prims_kdtree(
     # The Cython routines used require contiguous arrays
     if not X.flags["C_CONTIGUOUS"]:
         X = np.array(X, dtype=np.double, order="C")
-
+	    
+    if p!= 2 and 'p' not in kwargs:
+        kwargs['p'] = p
+	    
     tree = KDTree(X, metric=metric, leaf_size=leaf_size, **kwargs)
-
-    # TO DO: Deal with p for minkowski appropriately
+    
     dist_metric = DistanceMetric.get_metric(metric, **kwargs)
 
     # Get distance to kth nearest neighbour
@@ -292,7 +294,10 @@ def _hdbscan_prims_balltree(
     # The Cython routines used require contiguous arrays
     if not X.flags["C_CONTIGUOUS"]:
         X = np.array(X, dtype=np.double, order="C")
-
+	    
+    if p!= 2 and 'p' not in kwargs:
+        kwargs['p'] = p
+	    
     tree = BallTree(X, metric=metric, leaf_size=leaf_size, **kwargs)
 
     dist_metric = DistanceMetric.get_metric(metric, **kwargs)
@@ -335,7 +340,10 @@ def _hdbscan_boruvka_kdtree(
 
     if X.dtype != np.float64:
         X = X.astype(np.float64)
-
+	    
+    if p!= 2 and 'p' not in kwargs:
+        kwargs['p'] = p
+	    
     tree = KDTree(X, metric=metric, leaf_size=leaf_size, **kwargs)
     alg = KDTreeBoruvkaAlgorithm(
         tree,
@@ -379,7 +387,10 @@ def _hdbscan_boruvka_balltree(
 
     if X.dtype != np.float64:
         X = X.astype(np.float64)
-
+	    
+    if p!= 2 and 'p' not in kwargs:
+        kwargs['p'] = p
+	    
     tree = BallTree(X, metric=metric, leaf_size=leaf_size, **kwargs)
     alg = BallTreeBoruvkaAlgorithm(
         tree,
@@ -1137,7 +1148,10 @@ class HDBSCAN(BaseEstimator, ClusterMixin):
         self.prediction_data = prediction_data
 
         self._metric_kwargs = kwargs
-
+	    
+        if p is not None:
+            self._metric_kwargs['p'] = p
+		
         self._condensed_tree = None
         self._single_linkage_tree = None
         self._min_spanning_tree = None


### PR DESCRIPTION
Suggested quick fix to use p values other than 2 for minkowski. Setting _metric_kwargs in __init__ is for use in generate_prediction_data() and weighted_cluster_medoid().