### PR TITLE
Silence divide by zero warnings in branch detection code

### DIFF
--- a/hdbscan/branches.py
+++ b/hdbscan/branches.py
@@ -453,7 +453,8 @@ def _compute_branch_linkage_of_cluster(
     points = space_tree.data.base[cluster_points]
     centroid = np.average(points, weights=cluster_probabilities[cluster_mask], axis=0)
     centralities = dist_metric.pairwise(centroid[None], points)[0, :]
-    centralities = 1 / centralities
+    with np.errstate(divide="ignore"):
+        centralities = 1 / centralities
 
     # Construct cluster approximation graph
     if run_core:

--- a/hdbscan/plots.py
+++ b/hdbscan/plots.py
@@ -1128,7 +1128,7 @@ class ApproximationGraph:
                     g.add_edge(
                         row["parent"],
                         row["child"],
-                        weight=1 / row["mutual_reachability"],
+                        weight=1 / (1 + row["mutual_reachability"]),
                     )
                 self._pos = nx.nx_agraph.graphviz_layout(g, prog="sfdp")
             for k, v in self._pos.items():
@@ -1276,7 +1276,7 @@ class ApproximationGraph:
             - branch probability,
 
             Edge attributes:
-            - weight (1 / mutual_reachability),
+            - weight (1 / (1 + mutual_reachability)),
             - mutual_reachability,
             - centrality,
             - cluster label,
@@ -1293,7 +1293,7 @@ class ApproximationGraph:
         # Add edges
         for row in self._edges:
             attrs = dict(
-                weight=1 / row["mutual_reachability"],
+                weight=1 / (1 + row["mutual_reachability"]),
                 mutual_reachability=row["mutual_reachability"],
                 component=row["component"],
             )


### PR DESCRIPTION
This PR resolves #668 by silencing numpy's divide by zero warnings for the eccentricity computation. For the ApproximationGraph edge weights, I now divide by 1 / (1 + mutual reachability) instead. This makes the values lie between 0 and 1, which seems more appropriate for graph layout algorithms that use edge weight as a similarity value.