### PR TITLE
simplify_hierarchy and CondensedTree._select_clusters optimisations

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -79,7 +79,7 @@ def _tree_to_labels(
     set of labels and probabilities.
     """
     condensed_tree = condense_tree(single_linkage_tree, min_cluster_size)
-    if cluster_selection_persistence > 0.0:
+    if cluster_selection_persistence > 0.0 and condensed_tree.shape[0] > 0:
         condensed_tree = simplify_hierarchy(condensed_tree, cluster_selection_persistence)
     stability_dict = compute_stability(condensed_tree)
     labels, probabilities, stabilities = get_clusters(


### PR DESCRIPTION
This PR simplifies and optimises the `CondensedTree._select_clusters` and `simplify_hierarchy` functions. It turns out that the `simplify_hierarchy` operation reduces to iterating over the `cluster_tree` in reverse order (so children are processed before their parents).

The PR introduces one behavioural change to `simplify_hierarchy`. Density values are no longer updated when two leaves combine into one. This change ensures that the resulting leaf-combination retains its full density range. Consequently, the resulting simplified tree more accurately reflects the persistence threshold. Only when a leaf merges into a non-leaf are the leaf's density values updated to avoid breaking the condensed tree plot. Those points can have densities higher than the non-leaf's birth density, resulting in child clusters breaking off from a parent cluster before its icicle ends.