### PR TITLE
Fix resolve broken DOI link in README (10.7717/peerj-cs.2792)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,7 @@ Based on the paper:
     D.M. Bot, J. Peeters, J. Liesenborgs and J. Aerts
     *FLASC: a flare-sensitive clustering algorithm.*
     PeerJ Computer Science, Vol 11, April 2025, e2792.
-    https://doi.org/10.7717/peerj-cs.2792/.
+    https://doi.org/10.7717/peerj-cs.2792.
 
 ----------
 Installing


### PR DESCRIPTION
Before: “DOI Not Found” page

<img width="1075" height="723" alt="image" src="https://github.com/user-attachments/assets/5e423b8f-08dd-4641-87c9-7313ee8a92ad" />

After: Proper redirection to PeerJ article page

<img width="1335" height="635" alt="image" src="https://github.com/user-attachments/assets/fd516a6b-70e7-4eb3-b970-e76c9c756b6c" />
