### PR TITLE
Prevent hdbscan being installed with scikit-learn 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.20,<3
-scipy>= 1.0
-scikit-learn>=0.20
+scipy>=1.0
+scikit-learn>=0.20,<1.8
 joblib>=1.0


### PR DESCRIPTION
Quickly resolves: https://github.com/scikit-learn-contrib/hdbscan/issues/695

I would merge this, and if tests pass, just cut a new release asap to avoid a bunch of people hitting this 🙏 