### PR TITLE
Fix outlier scores

### DIFF
--- a/hdbscan/_hdbscan_tree.pyx
+++ b/hdbscan/_hdbscan_tree.pyx
@@ -560,15 +560,10 @@ cpdef np.ndarray[np.double_t, ndim=1] outlier_scores(np.ndarray tree):
     root_cluster = parent_array.min()
     result = np.zeros(root_cluster, dtype=np.double)
 
-    topological_sort_order = np.argsort(parent_array)
-    # topologically_sorted_tree = tree[topological_sort_order]
-
-    for n in topological_sort_order:
+    for n in range(tree.shape[0] - 1, -1, -1):
         cluster = child_array[n]
-        if cluster < root_cluster:
-            break
-
         parent = parent_array[n]
+        
         if deaths[cluster] > deaths[parent]:
             deaths[parent] = deaths[cluster]
 

--- a/hdbscan/prediction.py
+++ b/hdbscan/prediction.py
@@ -499,12 +499,11 @@ def approximate_predict_scores(clusterer, points_to_predict):
     for parent in np.unique(tree['parent']):
         max_lambdas[parent] = tree[tree['parent'] == parent]['lambda_val'].max()
 
-    for n in np.argsort(parent_array):
-        cluster = tree['child'][n]
-        if cluster < tree_root:
-            break
-
+    for n in range(tree.shape[0] - 1, -1, -1):
         parent = parent_array[n]
+        cluster = tree['child'][n]
+        if cluster not in max_lambdas:
+            continue
         if max_lambdas[cluster] > max_lambdas[parent]:
             max_lambdas[parent] = max_lambdas[cluster]
 


### PR DESCRIPTION
Fixes for #628 and potentially #116. Changes the outlier computation to use the maximum density in a parent's sub-tree, rather than the maximum density of its direct descendants.

For people relying on the current behaviour, this would be a breaking change of the outlier score.