### PR TITLE
Use manylinux_2_8 to build wheels on linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,10 +98,10 @@ stages:
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/release-'), eq(variables.triggeredByPullRequest, false))
     jobs:
       # Need to use manylinux as ubuntu-latest is too new
-      - job: Manylinux2014Build
+      - job: Manylinux_2_28_Build
         pool:
           vmImage: 'ubuntu-latest'
-        container: quay.io/pypa/manylinux2014_x86_64:latest
+        container: quay.io/pypa/manylinux_2_28_x86_64:latest
         strategy:
           matrix:
             linux_py310:
@@ -128,7 +128,7 @@ stages:
           env:
             PYBIN: /opt/python/$(python.version)/bin
         - bash: |
-            auditwheel repair dist/*linux_x86_64.whl --plat manylinux2014_x86_64 -w wheelhouse-manylinux/
+            auditwheel repair dist/*linux_x86_64.whl --plat manylinux_2_28_x86_64 -w wheelhouse-manylinux/
           displayName: 'Audit wheels'
         
         - task: DownloadSecureFile@1


### PR DESCRIPTION
Update the container used to build the Linux wheels since it had an old version of glibc which wasn't compatible with Cython>3. Hopefully this fixes the issues with linux wheels not being released. It's probably worth doing a new proper release (e.g. version 0.8.42) once it's merged to make sure all the wheels are on PyPI.

https://github.com/scikit-learn-contrib/hdbscan/issues/700
https://github.com/scikit-learn-contrib/hdbscan/issues/694
https://github.com/scikit-learn-contrib/hdbscan/issues/688
