### PR TITLE
Fix invalid escape sequence warning in robust_single_linkage docstring

### DIFF
--- a/hdbscan/robust_single_linkage_.py
+++ b/hdbscan/robust_single_linkage_.py
@@ -151,7 +151,7 @@ def robust_single_linkage(X, cut, k=5, alpha=1.4142135623730951,
                           gamma=5, metric='euclidean', algorithm='best',
                           memory=Memory(None, verbose=0), leaf_size=40,
                           core_dist_n_jobs=4, **kwargs):
-    """Perform robust single linkage clustering from a vector array
+    r"""Perform robust single linkage clustering from a vector array
     or distance matrix.
 
     Parameters


### PR DESCRIPTION
Resolves https://github.com/scikit-learn-contrib/hdbscan/issues/702

This is not a serious problem but have been seeing this warning when using HDBSCAN and the one character fix was simple enough