### PR TITLE
Remove unused cython imports in dist_metrics.pxd

### DIFF
--- a/hdbscan/dist_metrics.pxd
+++ b/hdbscan/dist_metrics.pxd
@@ -3,8 +3,6 @@
 #cython: wraparound=False
 #cython: cdivision=True
 
-import cython
-cimport cython
 
 import numpy as np
 cimport numpy as np


### PR DESCRIPTION
## Description

This PR removes unnecessary `import cython` and `cimport cython` statements from `hdbscan/hdbscan/dist_metrics.pxd`, as the cython namespace is not used anywhere in this module. This cleanup resolves issue #653.

## Type of change

- [x] Code cleanup / refactoring

## How Has This Been Tested?

- Verified that the cython namespace is not referenced in the file or its dependencies.
- Ran `nosetests -s hdbscan` locally; all tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable for this trivial change)
- [x] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (not applicable, but existing tests pass)
- [x] New and existing unit tests pass locally with my changes