### PR TITLE
Modernize wheel CI and add cp314 wheel support

### DIFF
--- a/.github/workflows/pythonpublish_wheel.yml
+++ b/.github/workflows/pythonpublish_wheel.yml
@@ -11,19 +11,25 @@ on:
 jobs:
   linux-deploy:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
+      fail-fast: false
       matrix:
-        python: ["cp38-cp38", "cp39-cp39", "cp310-cp310", "cp311-cp311"]
+        python:
+          - "cp310-cp310"
+          - "cp311-cp311"
+          - "cp312-cp312"
+          - "cp313-cp313"
+          - "cp314-cp314"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref }}
       - name: Build wheel
         env:
           PYTHON: /opt/python/${{ matrix.python }}/bin/python
         run: |
-          $PYTHON -m pip install "cython<3" oldest-supported-numpy
+          $PYTHON -m pip install --upgrade setuptools wheel build "cython>=3.0.11,<4" "numpy>=2.0"
           $PYTHON -m build --no-isolation
           auditwheel repair dist/*linux_x86_64.whl
       - name: Publish to pypi
@@ -36,23 +42,25 @@ jobs:
           twine upload wheelhouse/*.whl --skip-existing
   other-deploy:
     strategy:
+      fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
-        os: [windows-2019, macos-11]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [windows-2022, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref }}
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools build wheel twine
-          pip install cython "numpy>=2"
+          pip install "cython>=3.0.11,<4" "numpy>=2.0"
       - name: Build wheel
         run: |
           python -m build --no-isolation

--- a/hdbscan/_hdbscan_boruvka.pyx
+++ b/hdbscan/_hdbscan_boruvka.pyx
@@ -1,3 +1,4 @@
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 # cython: boundscheck=False
 # cython: nonecheck=False
 # cython: wraparound=False
@@ -89,7 +90,7 @@ cdef inline np.double_t balltree_min_dist_dual(
     np.double_t radius2,
     np.intp_t node1,
     np.intp_t node2,
-    np.double_t[:, ::1] centroid_dist) nogil except -1:
+    np.double_t[:, ::1] centroid_dist) except -1 nogil:
 
     cdef np.double_t dist_pt = centroid_dist[node1, node2]
     return max(0, (dist_pt - radius1 - radius2))
@@ -139,7 +140,7 @@ cdef inline np.double_t kdtree_min_rdist_dual(
     np.intp_t node1,
     np.intp_t node2,
     np.double_t[:, :, ::1] node_bounds,
-    np.intp_t num_features) nogil except -1:
+    np.intp_t num_features) except -1 nogil:
 
     cdef np.double_t d, d1, d2, rdist = 0.0
     cdef np.double_t zero = 0.0
@@ -603,7 +604,7 @@ cdef class KDTreeBoruvkaAlgorithm (object):
         return self.components.shape[0]
 
     cdef int dual_tree_traversal(self, np.intp_t node1,
-                                 np.intp_t node2) nogil except -1:
+                                 np.intp_t node2) except -1 nogil:
         """Perform a dual tree traversal, pruning wherever possible, to find
         the nearest neighbor not in the same component for each component.
         This is akin to a standard dual tree NN search, but we also prune

--- a/hdbscan/_hdbscan_linkage.pyx
+++ b/hdbscan/_hdbscan_linkage.pyx
@@ -1,3 +1,4 @@
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 # cython: boundscheck=False
 # cython: nonecheck=False
 # Minimum spanning tree single linkage implementation for hdbscan

--- a/hdbscan/_hdbscan_reachability.pyx
+++ b/hdbscan/_hdbscan_reachability.pyx
@@ -1,3 +1,4 @@
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 # cython: boundscheck=False
 # cython: nonecheck=False
 # cython: initializedcheck=False

--- a/hdbscan/_hdbscan_tree.pyx
+++ b/hdbscan/_hdbscan_tree.pyx
@@ -1,3 +1,4 @@
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 # cython: boundscheck=False
 # cython: nonecheck=False
 # cython: initializedcheck=False

--- a/hdbscan/_prediction_utils.pyx
+++ b/hdbscan/_prediction_utils.pyx
@@ -1,4 +1,5 @@
-#cython: boundscheck=False, nonecheck=False, initializedcheck=False
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
+# cython: boundscheck=False, nonecheck=False, initializedcheck=False
 # Utility routines in cython for prediction in hdbscan
 # Authors: Leland McInnes
 # License: 3-clause BSD

--- a/hdbscan/dist_metrics.pxd
+++ b/hdbscan/dist_metrics.pxd
@@ -1,7 +1,8 @@
 #!python
-#cython: boundscheck=False
-#cython: wraparound=False
-#cython: cdivision=True
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
 
 
 import numpy as np
@@ -31,7 +32,7 @@ DTYPE = np.double
 #  We use these for the default (euclidean) case so that they can be
 #  inlined.  This leads to faster computation for the most common case
 cdef inline DTYPE_t euclidean_dist(DTYPE_t* x1, DTYPE_t* x2,
-                                   ITYPE_t size) nogil except -1:
+                                   ITYPE_t size) except -1 nogil:
     cdef DTYPE_t tmp, d=0
     cdef np.intp_t j
     for j in range(size):
@@ -41,7 +42,7 @@ cdef inline DTYPE_t euclidean_dist(DTYPE_t* x1, DTYPE_t* x2,
 
 
 cdef inline DTYPE_t euclidean_rdist(DTYPE_t* x1, DTYPE_t* x2,
-                                    ITYPE_t size) nogil except -1:
+                                    ITYPE_t size) except -1 nogil:
     cdef DTYPE_t tmp, d=0
     cdef np.intp_t j
     for j in range(size):
@@ -50,7 +51,7 @@ cdef inline DTYPE_t euclidean_rdist(DTYPE_t* x1, DTYPE_t* x2,
     return d
 
 
-cdef inline DTYPE_t euclidean_dist_to_rdist(DTYPE_t dist) nogil except -1:
+cdef inline DTYPE_t euclidean_dist_to_rdist(DTYPE_t dist) except -1 nogil:
     return dist * dist
 
 
@@ -77,10 +78,10 @@ cdef class DistanceMetric:
     cdef object kwargs
 
     cdef DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                      ITYPE_t size) nogil except -1
+                      ITYPE_t size) except -1 nogil
 
     cdef DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                       ITYPE_t size) nogil except -1
+                       ITYPE_t size) except -1 nogil
 
     cdef int pdist(self, DTYPE_t[:, ::1] X, DTYPE_t[:, ::1] D) except -1
 
@@ -89,4 +90,4 @@ cdef class DistanceMetric:
 
     cdef DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1
 
-    cdef DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1
+    cdef DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil

--- a/hdbscan/dist_metrics.pyx
+++ b/hdbscan/dist_metrics.pyx
@@ -1,4 +1,5 @@
 # !python
+# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
 # cython: boundscheck=False
 # cython: wraparound=False
 # cython: cdivision=True
@@ -301,7 +302,7 @@ cdef class DistanceMetric:
             raise NotImplementedError("DistanceMetric is an abstract class")
 
     cdef DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                      ITYPE_t size) nogil except -1:
+                      ITYPE_t size) except -1 nogil:
         """Compute the distance between vectors x1 and x2
 
         This should be overridden in a base class.
@@ -309,7 +310,7 @@ cdef class DistanceMetric:
         return -999
 
     cdef DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                       ITYPE_t size) nogil except -1:
+                       ITYPE_t size) except -1 nogil:
         """Compute the reduced distance between vectors x1 and x2.
 
         This can optionally be overridden in a base class.
@@ -345,7 +346,7 @@ cdef class DistanceMetric:
         """Convert the reduced distance to the distance"""
         return rdist
 
-    cdef DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
+    cdef DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil:
         """Convert the distance to the reduced distance"""
         return dist
 
@@ -422,17 +423,17 @@ cdef class EuclideanDistance(DistanceMetric):
         self.p = 2
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         return euclidean_dist(x1, x2, size)
 
     cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                              ITYPE_t size) nogil except -1:
+                              ITYPE_t size) except -1 nogil:
         return euclidean_rdist(x1, x2, size)
 
     cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
         return sqrt(rdist)
 
-    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
+    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -458,7 +459,7 @@ cdef class SEuclideanDistance(DistanceMetric):
         self.p = 2
 
     cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                              ITYPE_t size) nogil except -1:
+                              ITYPE_t size) except -1 nogil:
         if size != self.size:
             with gil:
                 raise ValueError('SEuclidean dist: size of V does not match')
@@ -470,13 +471,13 @@ cdef class SEuclideanDistance(DistanceMetric):
         return d
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
     cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
         return sqrt(rdist)
 
-    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
+    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -499,7 +500,7 @@ cdef class ManhattanDistance(DistanceMetric):
         self.p = 1
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef DTYPE_t d = 0
         cdef np.intp_t j
         for j in range(size):
@@ -520,7 +521,7 @@ cdef class ChebyshevDistance(DistanceMetric):
         self.p = INF
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef DTYPE_t d = 0
         cdef np.intp_t j
         for j in range(size):
@@ -551,7 +552,7 @@ cdef class MinkowskiDistance(DistanceMetric):
         self.p = p
 
     cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                              ITYPE_t size) nogil except -1:
+                              ITYPE_t size) except -1 nogil:
         cdef DTYPE_t d=0
         cdef np.intp_t j
         for j in range(size):
@@ -559,13 +560,13 @@ cdef class MinkowskiDistance(DistanceMetric):
         return d
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
     cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
         return pow(rdist, 1. / self.p)
 
-    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
+    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil:
         return pow(dist, self.p)
 
     def rdist_to_dist(self, rdist):
@@ -606,7 +607,7 @@ cdef class WMinkowskiDistance(DistanceMetric):
         self.size = self.vec.shape[0]
 
     cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                              ITYPE_t size) nogil except -1:
+                              ITYPE_t size) except -1 nogil:
         if size != self.size:
             with gil:
                 raise ValueError('WMinkowskiDistance dist: '
@@ -618,13 +619,13 @@ cdef class WMinkowskiDistance(DistanceMetric):
         return d
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
     cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
         return pow(rdist, 1. / self.p)
 
-    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
+    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil:
         return pow(dist, self.p)
 
     def rdist_to_dist(self, rdist):
@@ -668,7 +669,7 @@ cdef class MahalanobisDistance(DistanceMetric):
         self.vec_ptr = get_vec_ptr(self.vec)
 
     cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                              ITYPE_t size) nogil except -1:
+                              ITYPE_t size) except -1 nogil:
         if size != self.size:
             with gil:
                 raise ValueError('Mahalanobis dist: size of V does not match')
@@ -688,13 +689,13 @@ cdef class MahalanobisDistance(DistanceMetric):
         return d
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
     cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
         return sqrt(rdist)
 
-    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
+    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -717,7 +718,7 @@ cdef class HammingDistance(DistanceMetric):
        D(x, y) = \frac{1}{N} \sum_i \delta_{x_i, y_i}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int n_unequal = 0
         cdef np.intp_t j
         for j in range(size):
@@ -739,7 +740,7 @@ cdef class CanberraDistance(DistanceMetric):
        D(x, y) = \sum_i \frac{|x_i - y_i|}{|x_i| + |y_i|}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef DTYPE_t denom, d = 0
         cdef np.intp_t j
         for j in range(size):
@@ -762,7 +763,7 @@ cdef class BrayCurtisDistance(DistanceMetric):
        D(x, y) = \frac{\sum_i |x_i - y_i|}{\sum_i(|x_i| + |y_i|)}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef DTYPE_t num = 0, denom = 0
         cdef np.intp_t j
         for j in range(size):
@@ -788,7 +789,7 @@ cdef class JaccardDistance(DistanceMetric):
        D(x, y) = \frac{N_{TF} + N_{FT}}{N_{TT} + N_{TF} + N_{FT}}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, n_eq = 0, nnz = 0
         cdef np.intp_t j
         for j in range(size):
@@ -815,7 +816,7 @@ cdef class MatchingDistance(DistanceMetric):
        D(x, y) = \frac{N_{TF} + N_{FT}}{N}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, n_neq = 0
         cdef np.intp_t j
         for j in range(size):
@@ -839,7 +840,7 @@ cdef class DiceDistance(DistanceMetric):
        D(x, y) = \frac{N_{TF} + N_{FT}}{2 * N_{TT} + N_{TF} + N_{FT}}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, n_neq = 0, ntt = 0
         cdef np.intp_t j
         for j in range(size):
@@ -864,7 +865,7 @@ cdef class KulsinskiDistance(DistanceMetric):
        D(x, y) = 1 - \frac{N_{TT}}{N + N_{TF} + N_{FT}}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, ntt = 0, n_neq = 0
         cdef np.intp_t j
         for j in range(size):
@@ -889,7 +890,7 @@ cdef class RogersTanimotoDistance(DistanceMetric):
        D(x, y) = \frac{2 (N_{TF} + N_{FT})}{N + N_{TF} + N_{FT}}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, n_neq = 0
         cdef np.intp_t j
         for j in range(size):
@@ -913,7 +914,7 @@ cdef class RussellRaoDistance(DistanceMetric):
        D(x, y) = \frac{N - N_{TT}}{N}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, ntt = 0
         cdef np.intp_t j
         for j in range(size):
@@ -937,7 +938,7 @@ cdef class SokalMichenerDistance(DistanceMetric):
        D(x, y) = \frac{2 (N_{TF} + N_{FT})}{N + N_{TF} + N_{FT}}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, n_neq = 0
         cdef np.intp_t j
         for j in range(size):
@@ -961,7 +962,7 @@ cdef class SokalSneathDistance(DistanceMetric):
        D(x, y) = \frac{N_{TF} + N_{FT}}{N_{TT} / 2 + N_{TF} + N_{FT}}
     """
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef int tf1, tf2, ntt = 0, n_neq = 0
         cdef np.intp_t j
         for j in range(size):
@@ -989,7 +990,7 @@ cdef class HaversineDistance(DistanceMetric):
                                 + cos(x1)cos(y1)sin^2((x2 - y2) / 2)}]
     """
     cdef inline DTYPE_t rdist(self, DTYPE_t* x1, DTYPE_t* x2,
-                              ITYPE_t size) nogil except -1:
+                              ITYPE_t size) except -1 nogil:
         if size != 2:
             with gil:
                 raise ValueError("Haversine distance only valid "
@@ -999,7 +1000,7 @@ cdef class HaversineDistance(DistanceMetric):
         return (sin_0 * sin_0 + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1)
 
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         if size != 2:
             with gil:
                 raise ValueError("Haversine distance only valid in"
@@ -1012,7 +1013,7 @@ cdef class HaversineDistance(DistanceMetric):
     cdef inline DTYPE_t _rdist_to_dist(self, DTYPE_t rdist) except -1:
         return 2 * asin(sqrt(rdist))
 
-    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) nogil except -1:
+    cdef inline DTYPE_t _dist_to_rdist(self, DTYPE_t dist) except -1 nogil:
         cdef DTYPE_t tmp = sin(0.5 * dist)
         return tmp * tmp
 
@@ -1051,7 +1052,7 @@ cdef class HaversineDistance(DistanceMetric):
 
 # cdef class CosineDistance(DistanceMetric):
 #    cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-#                             ITYPE_t size) nogil except -1:
+#                             ITYPE_t size) except -1 nogil:
 #        cdef DTYPE_t d = 0, norm1 = 0, norm2 = 0
 #        cdef np.intp_t j
 #        for j in range(size):
@@ -1066,7 +1067,7 @@ cdef class HaversineDistance(DistanceMetric):
 
 cdef class ArccosDistance(DistanceMetric):
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         cdef DTYPE_t d = 0, norm1 = 0, norm2 = 0
         cdef np.intp_t j
         for j in range(size):
@@ -1124,7 +1125,7 @@ cdef class PyFuncDistance(DistanceMetric):
     # only way to be back compatible is to inherit `dist` from the base class
     # without GIL and called an inline `_dist` which acquire GIL.
     cdef inline DTYPE_t dist(self, DTYPE_t* x1, DTYPE_t* x2,
-                             ITYPE_t size) nogil except -1:
+                             ITYPE_t size) except -1 nogil:
         return self._dist(x1, x2, size)
 
     cdef inline DTYPE_t _dist(self, DTYPE_t* x1, DTYPE_t* x2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = [
   "setuptools>=64",
   "wheel",
-  "cython<4",
-  "numpy<3"
+  "cython>=3.0.11,<4",
+  "numpy>=2.0,<3"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -12,6 +12,7 @@ name = "hdbscan"
 version = "0.8.42"
 description = "Clustering based on density with variable density clusters"
 readme = "README.rst"
+requires-python = ">=3.10"
 license = {text = "BSD"}
 authors = [
   {name = "Leland McInnes", email = "leland.mcinnes@gmail.com"}
@@ -35,6 +36,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [


### PR DESCRIPTION
## Summary

PyPI currently has wheels for hdbscan 0.8.42 covering cp310–cp313 on
Linux/macOS/Windows, but the `pythonpublish_wheel.yml` workflow that's
checked in doesn't actually produce them — it still pins `cython<3` inside
a `manylinux2014` container and only matrices cp38–cp311. The current
wheels must have been built out-of-band (cibuildwheel locally, or via a
workflow tweaked at release time and never committed). cp314 wheels haven't
been published yet, and the workflow as-checked-in can't produce them
either: Python 3.14 needs glibc ≥ 2.28 and refuses to compile against
Cython 2.

This PR brings the committed workflow into a state where simply dispatching
it for the next release produces a complete, current wheel set — including
cp314.

## Build system (`pyproject.toml`)

- `[build-system]` now requires `cython>=3.0.11,<4` and `numpy>=2.0,<3` so
  any source build (CI, conda-forge, end-user `pip install`) targets
  current Cython/NumPy.
- `requires-python = ">=3.10"` matches the supported matrix — Python 3.8
  reached EOL on 2024-10-07 and 3.9 on 2025-10-31.
- Adds the `Programming Language :: Python :: 3.14` classifier.

## Cython 3 source updates

- Reorders `nogil except -1` → `except -1 nogil` across `.pyx`/`.pxd`
  (Cython 3 syntax requirement).
- Adds `# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION`
  to silence NumPy deprecated-API warnings.

This rebases the still-relevant source-file hunks of #691 onto current
master.

## Wheel CI (`.github/workflows/pythonpublish_wheel.yml`)

- **Linux**: `manylinux2014_x86_64` → `manylinux_2_28_x86_64` (Python 3.14
  needs glibc ≥ 2.28). Pins `cython>=3.0.11,<4` and `numpy>=2.0` in the
  build env, installs `setuptools`+`wheel` (the cp314 image doesn't ship
  them by default), and extends the matrix to cp310–cp314.
- **Windows/macOS**: replaces deprecated `oldest-supported-numpy` with
  `numpy>=2.0`, bumps `actions/checkout` v1→v4 and `actions/setup-python`
  v1→v5 (v1 doesn't support recent Pythons), retires the EOL
  `windows-2019` / `macos-11` runners (now `windows-2022` + `macos-14` —
  macOS 14 already produces universal2 wheels covering arm64 and x86_64),
  extends the matrix to 3.10–3.14, and enables `allow-prereleases: true`
  for 3.14.
- Disables `fail-fast` on both matrices so one failure doesn't cancel the
  rest.

## Verification

- All 15 build jobs (Linux cp310–cp314, Windows + macOS for 3.10–3.14) go
  green on a `workflow_dispatch` run on the author's fork.
- Locally on Python 3.14.4 with Cython 3.2.4 + NumPy 2.4.4: every extension
  cythonizes and compiles cleanly, and `HDBSCAN().fit(X)` runs end-to-end.

Consistent with how conda-forge already ships working py314 builds.
Relates to #688, #686 (the underlying Linux wheels for 3.12/3.13 are
already on PyPI, but a future release using this workflow won't need
out-of-band builds). Supersedes #691 for the parts still relevant.