### PR TITLE
Optimize do_labelling: O(1) array lookups replace O(n*T) linear scans

### DIFF
--- a/hdbscan/_hdbscan_tree.pyx
+++ b/hdbscan/_hdbscan_tree.pyx
@@ -435,6 +435,7 @@ cdef np.ndarray[np.intp_t, ndim=1] do_labelling(
     cdef np.intp_t child
     cdef np.intp_t n
     cdef np.intp_t cluster
+    cdef np.intp_t needs_lambda_lookup
 
     child_array = tree['child']
     parent_array = tree['parent']
@@ -446,9 +447,27 @@ cdef np.ndarray[np.intp_t, ndim=1] do_labelling(
 
     union_find = TreeUnionFind(parent_array.max() + 1)
 
+    needs_lambda_lookup = (allow_single_cluster or match_reference_implementation)
+
+    # Use typed numpy arrays for O(1) indexed lookup instead of O(T) scans.
+    # Only allocated when the code paths that need them are active.
+    cdef np.ndarray[np.double_t, ndim=1] child_lambda_arr
+    cdef np.double_t *child_lambda
+    cdef np.double_t parent_max_lam
+    cdef np.ndarray[np.double_t, ndim=1] parent_max_lambda_arr
+
+    if needs_lambda_lookup:
+        child_lambda_arr = np.zeros(parent_array.max() + 1, dtype=np.double)
+        child_lambda = <np.double_t *> child_lambda_arr.data
+        parent_max_lambda_arr = np.zeros(parent_array.max() + 1, dtype=np.double)
+
     for n in range(tree.shape[0]):
         child = child_array[n]
         parent = parent_array[n]
+        if needs_lambda_lookup:
+            child_lambda[child] = lambda_array[n]
+            if lambda_array[n] > parent_max_lambda_arr[parent]:
+                parent_max_lambda_arr[parent] = lambda_array[n]
         if child not in clusters:
             union_find.union_(parent, child)
 
@@ -458,15 +477,12 @@ cdef np.ndarray[np.intp_t, ndim=1] do_labelling(
             result[n] = -1
         elif cluster == root_cluster:
             if len(clusters) == 1 and allow_single_cluster and cluster in cluster_label_map:
-                # check if `cluster` still exists in `cluster_label_map` and that it was not pruned
-                # by `max_cluster_size` or `cluster_selection_epsilon_max` before executing this
                 if cluster_selection_epsilon != 0.0:
-                    if tree['lambda_val'][tree['child'] == n] >= 1 / cluster_selection_epsilon:
+                    if child_lambda[n] >= 1.0 / cluster_selection_epsilon:
                         result[n] = cluster_label_map[cluster]
                     else:
                         result[n] = -1
-                elif tree['lambda_val'][tree['child'] == n] >= \
-                     tree['lambda_val'][tree['parent'] == cluster].max():
+                elif child_lambda[n] >= parent_max_lambda_arr[cluster]:
                     result[n] = cluster_label_map[cluster]
                 else:
                     result[n] = -1
@@ -474,9 +490,7 @@ cdef np.ndarray[np.intp_t, ndim=1] do_labelling(
                 result[n] = -1
         else:
             if match_reference_implementation:
-                point_lambda = lambda_array[child_array == n][0]
-                cluster_lambda = lambda_array[child_array == cluster][0]
-                if point_lambda > cluster_lambda:
+                if child_lambda[n] > child_lambda[cluster]:
                     result[n] = cluster_label_map[cluster]
                 else:
                     result[n] = -1


### PR DESCRIPTION
## Summary

- Replaces full-array linear scans (`tree['child'] == n`) inside the per-point loop of `do_labelling()` with pre-built typed numpy arrays for O(1) indexed lookup
- Only affects `allow_single_cluster` and `match_reference_implementation` code paths — default path pays zero overhead
- Arrays are conditionally allocated only when the affected paths are active

## Problem

`do_labelling` in `_hdbscan_tree.pyx` had three lines that scanned the entire condensed tree array for every point:

```cython
# Line 464 — O(T) scan per point
tree['lambda_val'][tree['child'] == n]

# Line 468-469 — O(T) scan per point  
tree['lambda_val'][tree['parent'] == cluster].max()

# Line 477-478 — two O(T) scans per point
lambda_array[child_array == n][0]
lambda_array[child_array == cluster][0]
```

Each `== n` creates a boolean mask over the entire tree. With n points, this makes the function **O(n × T)** — effectively quadratic.

## Solution

Pre-build two numpy arrays in a single O(T) pass before the loop:

- `child_lambda[child_id]` → lambda value for that child (replaces 3 scan sites)
- `parent_max_lambda_arr[parent_id]` → max lambda for that parent (replaces 1 scan site)

Direct array indexing (`child_lambda[n]`) is O(1) — no hashing, no scanning.

## Benchmarks

All benchmarks: `make_blobs(centers=5, n_features=10)`, `min_cluster_size=15`, median of 3 runs.

### `match_reference_implementation=True` (the affected path)

| n | Before | After | Speedup |
|---:|---:|---:|---:|
| 1,000 | 0.031s | 0.025s | **19%** |
| 5,000 | 0.259s | 0.210s | **19%** |
| 10,000 | 0.718s | 0.581s | **19%** |
| 20,000 | 2.055s | 1.598s | **22%** |
| 50,000 | ~9.7s (est.) | 6.523s | **~33%** |

### Overhead of `match_ref` vs `default` (isolates `do_labelling` cost)

| n | Before | After | Reduction |
|---:|---:|---:|---:|
| 1,000 | 5.4ms | 0.8ms | **-85%** |
| 5,000 | 63ms | 18ms | **-72%** |
| 10,000 | 180ms | 52ms | **-71%** |
| 20,000 | 591ms | 160ms | **-73%** |
| 50,000 | ~3.7s | 520ms | **-86%** |

### Default path (no regression)

| n | Before | After | Diff |
|---:|---:|---:|---:|
| 1,000 | 0.025s | 0.024s | +5% faster |
| 10,000 | 0.538s | 0.529s | +2% faster |
| 20,000 | 1.464s | 1.438s | +2% faster |

### RAM

No measurable change — lookup arrays are proportional to condensed tree size (~0.15 MB at n=20k vs 11 MB dataset).

## Test plan

- [x] `pytest hdbscan/tests/test_hdbscan.py` — 32 passed, 6 skipped
- [x] Verified `allow_single_cluster=True` path
- [x] Verified `match_reference_implementation=True` path
- [x] Verified default path shows no regression