### PR TITLE
Optimize get_stability_scores: O(n) bincount replaces O(k*n) loop

### DIFF
--- a/hdbscan/_hdbscan_tree.pyx
+++ b/hdbscan/_hdbscan_tree.pyx
@@ -591,9 +591,17 @@ cpdef np.ndarray get_stability_scores(np.ndarray labels, set clusters,
     cdef np.intp_t cluster_size
     cdef np.intp_t n
 
-    result = np.empty(len(clusters), dtype=np.double)
+    # One O(n) pass to count all cluster sizes, instead of O(n) per cluster.
+    cdef np.ndarray[np.intp_t, ndim=1] cluster_sizes
+    cdef np.intp_t num_labels = len(clusters)
+    if num_labels > 0:
+        cluster_sizes = np.bincount(labels[labels >= 0], minlength=num_labels)
+    else:
+        cluster_sizes = np.zeros(0, dtype=np.intp)
+
+    result = np.empty(num_labels, dtype=np.double)
     for n, c in enumerate(sorted(list(clusters))):
-        cluster_size = np.sum(labels == n)
+        cluster_size = cluster_sizes[n] if n < cluster_sizes.shape[0] else 0
         if np.isinf(max_lambda) or max_lambda == 0.0 or cluster_size == 0:
             result[n] = 1.0
         else:


### PR DESCRIPTION
## Summary

- Replaces per-cluster `np.sum(labels == n)` calls with a single `np.bincount` for all cluster sizes at once
- Reduces `get_stability_scores` from O(k × n) to O(n + k)
- No behavior change — same results, just faster counting

## Problem

`get_stability_scores` computed each cluster's size by scanning the entire labels array:

```cython
for n, c in enumerate(sorted(list(clusters))):
    cluster_size = np.sum(labels == n)   # O(n) scan, repeated k times
```

With k clusters and n points, this is **O(k × n)**. For 50 clusters and 50k points, that's 2.5M comparisons.

## Solution

One `np.bincount` call counts all cluster sizes in a single O(n) pass:

```cython
cluster_sizes = np.bincount(labels[labels >= 0], minlength=num_labels)
# then: cluster_size = cluster_sizes[n]  — O(1) lookup
```

## Benchmarks

### Isolated function (median of 5 runs, 100 iterations each)

| n | clusters | Before (µs) | After (µs) | Speedup |
|---:|---:|---:|---:|---:|
| 5,000 | 5 | 14.3 | 12.7 | 1.1× |
| 5,000 | 50 | 143.5 | 23.2 | **6.2×** |
| 10,000 | 50 | 223.2 | 32.8 | **6.8×** |
| 20,000 | 50 | 351.9 | 42.9 | **8.2×** |
| 50,000 | 50 | 666.5 | 83.5 | **8.0×** |

The speedup grows with more clusters (k), since bincount eliminates the k-factor entirely.

### Full `fit_predict` pipeline

End-to-end impact is ~1-7% since `get_stability_scores` is a small fraction of total runtime. No regression in any configuration.

### RAM

No measurable change (0.00 MB diff across all sizes).

## Test plan

- [x] `pytest hdbscan/tests/test_hdbscan.py` — 32 passed, 6 skipped
- [x] Verified with 5 and 50 clusters
- [x] Verified no regression on default path