### PR TITLE
Optimize gen_min_span_tree: set lookups replace O(n^2) array copies

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -152,14 +152,21 @@ def _hdbscan_generic(
     # returned by mst_linkage_core (i.e. just the order of points to be merged)
     if gen_min_span_tree:
         result_min_span_tree = min_spanning_tree.copy()
+        # Build a set of merged points incrementally instead of copying
+        # a growing slice of the MST array on every iteration.
+        merged = set(int(min_spanning_tree[0, c]) for c in range(2))
         for index, row in enumerate(result_min_span_tree[1:], 1):
-            candidates = np.where(isclose(mutual_reachability_[int(row[1])], row[2]))[0]
-            candidates = np.intersect1d(
-                candidates, min_spanning_tree[:index, :2].astype(int)
-            )
-            candidates = candidates[candidates != row[1]]
-            assert len(candidates) > 0
-            row[0] = candidates[0]
+            point = int(row[1])
+            weight = row[2]
+            mr_row = mutual_reachability_[point]
+            for c in np.where(isclose(mr_row, weight))[0]:
+                if c != point and int(c) in merged:
+                    row[0] = c
+                    break
+            else:
+                assert False, "No candidate found for MST edge reconstruction"
+            merged.add(int(min_spanning_tree[index, 0]))
+            merged.add(int(min_spanning_tree[index, 1]))
     else:
         result_min_span_tree = None
 


### PR DESCRIPTION
## Summary

- Replaces growing array slice + `np.intersect1d` with an incrementally-built `set` for O(1) membership checks
- Short-circuits candidate search on first match instead of materializing the full intersection
- Only affects the `gen_min_span_tree=True` code path (off by default)

## Problem

The MST reconstruction loop did this on every iteration:

```python
for index, row in enumerate(result_min_span_tree[1:], 1):
    candidates = np.where(isclose(mr[int(row[1])], row[2]))[0]      # O(n) scan
    candidates = np.intersect1d(
        candidates, min_spanning_tree[:index, :2].astype(int)        # O(index) COPY
    )                                                                 # O(n) intersect
```

`min_spanning_tree[:index, :2].astype(int)` copies a growing slice of the array **every iteration**. With n-1 iterations: total copy work = 1 + 2 + ... + (n-1) = **O(n²)**.

## Solution

Maintain a `set` of merged point IDs, updated incrementally (O(1) add per iteration). Check candidates against the set directly, breaking on first match:

```python
merged = set(...)
for index, row in enumerate(result_min_span_tree[1:], 1):
    for c in np.where(isclose(mr_row, weight))[0]:
        if c != point and int(c) in merged:          # O(1) set lookup
            row[0] = c
            break
    merged.add(...)
```

## Benchmarks

All benchmarks: `algorithm='generic'`, `make_blobs(centers=5, n_features=10)`, median of 3 runs.

### `gen_min_span_tree=True` — full pipeline

| n | Before | After | Speedup |
|---:|---:|---:|---:|
| 1,000 | 0.113s | 0.068s | **39%** |
| 2,000 | 0.311s | 0.166s | **47%** |
| 5,000 | 1.604s | 0.740s | **54%** |
| 8,000 | 3.892s | 1.763s | **55%** |
| 10,000 | 6.018s | 2.450s | **59%** |

### Isolated overhead (gen_mst=True minus gen_mst=False)

| n | Before | After | Reduction |
|---:|---:|---:|---:|
| 1,000 | 79ms | 36ms | **-54%** |
| 2,000 | 220ms | 76ms | **-65%** |
| 5,000 | 1.03s | 0.21s | **-80%** |
| 8,000 | 2.55s | 0.39s | **-85%** |
| 10,000 | 3.94s | 0.40s | **-90%** |

### Scaling improvement

| n | Before overhead ratio | After overhead ratio |
|---:|---:|---:|
| 1k (base) | 1.0× | 1.0× |
| 5k | 13.1× | 5.7× |
| 10k | 50.0× | 11.2× |

Before: overhead grew **~50×** from 1k→10k (quadratic).
After: overhead grew **~11×** (sub-quadratic).

### RAM

No change — the `set` replaces array copies that were already transient.

## Test plan

- [x] `pytest hdbscan/tests/test_hdbscan.py` — 32 passed, 6 skipped
- [x] Verified MST reconstruction produces valid tree (2000 nodes, 1999 edges, all weights > 0, no NaN)
- [x] `gen_min_span_tree=False` path unchanged (no regression)