### PR TITLE
Reduce mutual_reachability peak memory by 51% via in-place ops

### DIFF
--- a/hdbscan/_hdbscan_reachability.pyx
+++ b/hdbscan/_hdbscan_reachability.pyx
@@ -51,13 +51,13 @@ def mutual_reachability(distance_matrix, min_points=5, alpha=1.0):
                                  axis=0)[min_points]
 
     if alpha != 1.0:
-        distance_matrix = distance_matrix / alpha
+        np.divide(distance_matrix, alpha, out=distance_matrix)
 
-    stage1 = np.where(core_distances > distance_matrix,
-                      core_distances, distance_matrix)
-    result = np.where(core_distances > stage1.T,
-                      core_distances.T, stage1.T).T
-    return result
+    # In-place on distance_matrix: avoids allocating any n*n intermediates.
+    # Callers do not use distance_matrix after this call.
+    np.maximum(distance_matrix, core_distances, out=distance_matrix)
+    np.maximum(distance_matrix, core_distances[:, None], out=distance_matrix)
+    return distance_matrix
 
 
 cpdef sparse_mutual_reachability(object lil_matrix, np.intp_t min_points=5,


### PR DESCRIPTION
## Summary

- Replaces two intermediate n×n array allocations with in-place `np.maximum` on the input `distance_matrix`
- Reduces peak memory from ~4.1× to ~2.0× the n×n matrix size (**51% reduction**)
- Also uses in-place `np.divide` for the alpha scaling path

## Problem

`mutual_reachability` created two temporary n×n arrays:

```python
# Before: 2 intermediate n*n arrays
stage1 = np.where(core_distances > distance_matrix,       # n*n alloc #1
                  core_distances, distance_matrix)
result = np.where(core_distances > stage1.T,              # n*n alloc #2
                  core_distances.T, stage1.T).T
```

For n=10k (float64), each n×n matrix is ~763 MB. At peak, 3 lived simultaneously: the input `distance_matrix` + `stage1` + `result` = ~2.3 GB just in intermediates.

## Solution

Operate in-place on `distance_matrix`, which callers (`_hdbscan_generic`, `_rsl_generic`) do not reference after this call:

```python
# After: zero intermediate allocations
np.maximum(distance_matrix, core_distances, out=distance_matrix)
np.maximum(distance_matrix, core_distances[:, None], out=distance_matrix)
return distance_matrix
```

## Benchmarks

All benchmarks: `algorithm='generic'`, `make_blobs(centers=5, n_features=10)`, median of 3 runs.

### Peak memory

| n | Before | After | Saved | % |
|---:|---:|---:|---:|---:|
| 1,000 | 31.5 MB | 15.3 MB | 16 MB | **-51%** |
| 2,000 | 126 MB | 61 MB | 65 MB | **-52%** |
| 5,000 | 787 MB | 382 MB | 405 MB | **-52%** |
| 8,000 | 2,014 MB | 977 MB | 1,038 MB | **-52%** |
| 10,000 | 3,147 MB | 1,526 MB | 1,621 MB | **-52%** |

Peak memory ratio to n×n matrix size: **4.1× → 2.0×**

### Speed

| n | Before | After | Diff |
|---:|---:|---:|---:|
| 1,000 | 0.037s | 0.033s | +10% |
| 2,000 | 0.093s | 0.085s | +9% |
| 8,000 | 1.364s | 1.269s | +7% |
| 10,000 | 1.877s | 1.820s | +3% |

No regression; modest speedup from reduced allocation pressure.

## Safety

Both callers of `mutual_reachability()` assign the result to a new variable (`mutual_reachability_`) and never reference `distance_matrix` again:

- `hdbscan_.py:136` — `_hdbscan_generic`: distance_matrix unused after line 136
- `robust_single_linkage_.py:48` — `_rsl_generic`: distance_matrix unused after line 48

The `precomputed` metric path already copies the input (`X.copy()`) at line 119, so user data is never mutated.

## Test plan

- [x] `pytest hdbscan/tests/` — 71 passed, 14 skipped
- [x] Verified clustering results identical (labels, probabilities, noise count)
- [x] Verified both callers don't use distance_matrix post-call
- [x] Verified precomputed metric path copies input first