### PR TITLE
Vectorize _remap_edge_lists and _remap_point_lists: 6-14x faster

### DIFF
--- a/hdbscan/branches.py
+++ b/hdbscan/branches.py
@@ -707,10 +707,13 @@ def _remap_edge_lists(edge_lists, internal_to_raw):
     internal_to_raw: dict
         A mapping from internal integer index to the raw integer index.
     """
+    max_key = max(internal_to_raw.keys())
+    lookup = np.empty(max_key + 1, dtype=np.intp)
+    for k, v in internal_to_raw.items():
+        lookup[k] = v
     for graph in edge_lists:
-        for edge in graph:
-            edge[0] = internal_to_raw[edge[0]]
-            edge[1] = internal_to_raw[edge[1]]
+        graph[:, 0] = lookup[graph[:, 0].astype(np.intp)]
+        graph[:, 1] = lookup[graph[:, 1].astype(np.intp)]
 
 
 def _remap_point_lists(point_lists, internal_to_raw):
@@ -724,9 +727,12 @@ def _remap_point_lists(point_lists, internal_to_raw):
     internal_to_raw: dict
         A mapping from internal integer index to the raw integer index.
     """
+    max_key = max(internal_to_raw.keys())
+    lookup = np.empty(max_key + 1, dtype=np.intp)
+    for k, v in internal_to_raw.items():
+        lookup[k] = v
     for points in point_lists:
-        for idx in range(len(points)):
-            points[idx] = internal_to_raw[points[idx]]
+        points[:] = lookup[points.astype(np.intp)]
 
 
 def _remap_labels(old_labels, finite_index, num_points, fill_value=-1):


### PR DESCRIPTION
## Summary

- Replaces Python-level element-by-element loops with numpy fancy indexing
- Builds a lookup array from the dict once, then remaps entire columns in one vectorized operation
- Affects branch detection post-processing (`_remap_edge_lists`, `_remap_point_lists`)

## Problem

Both functions iterated over numpy arrays in Python, doing dict lookups per element:

```python
for graph in edge_lists:
    for edge in graph:                         # Python loop over numpy rows
        edge[0] = internal_to_raw[edge[0]]     # dict lookup per element
        edge[1] = internal_to_raw[edge[1]]
```

Python iteration over numpy arrays is ~10-100× slower than vectorized ops because of per-element boxing/unboxing overhead.

## Solution

Build a numpy lookup array from the dict once (O(max_key)), then use fancy indexing to remap all elements in one vectorized op:

```python
lookup = np.empty(max_key + 1, dtype=np.intp)
for k, v in internal_to_raw.items():
    lookup[k] = v
for graph in edge_lists:
    graph[:, 0] = lookup[graph[:, 0].astype(np.intp)]
    graph[:, 1] = lookup[graph[:, 1].astype(np.intp)]
```

## Benchmarks

5 graphs per run, median of 5 runs.

### `_remap_edge_lists`

| Edges | Before | After | Speedup |
|---:|---:|---:|---:|
| 1,000 | 0.98ms | 0.07ms | **14×** |
| 5,000 | 4.82ms | 0.35ms | **14×** |
| 10,000 | 9.53ms | 0.76ms | **13×** |
| 50,000 | 54.1ms | 3.75ms | **14×** |
| 100,000 | 112ms | 7.67ms | **15×** |

### `_remap_point_lists`

| Points | Before | After | Speedup |
|---:|---:|---:|---:|
| 1,000 | 0.35ms | 0.07ms | **5×** |
| 5,000 | 1.91ms | 0.33ms | **6×** |
| 10,000 | 3.86ms | 0.69ms | **6×** |
| 50,000 | 19.4ms | 3.38ms | **6×** |
| 100,000 | 38.8ms | 6.76ms | **6×** |

### RAM

Negligible — lookup array is proportional to `max(internal_to_raw.keys())`, not to data size.

## Test plan

- [x] `pytest hdbscan/tests/test_branches.py` — 16 passed, 7 skipped
- [x] Speedup consistent across all sizes