### PR TITLE
Replace per-cluster tree scans with a single grouped reduction

### DIFF
--- a/hdbscan/branches.py
+++ b/hdbscan/branches.py
@@ -9,7 +9,7 @@ from joblib import Parallel, delayed
 from joblib.parallel import cpu_count
 from ._hdbscan_linkage import label
 from .plots import CondensedTree, SingleLinkageTree, ApproximationGraph
-from .prediction import approximate_predict
+from .prediction import approximate_predict, _group_by_parent
 from ._hdbscan_tree import recurse_leaf_dfs
 from .hdbscan_ import _tree_to_labels
 
@@ -1134,16 +1134,18 @@ class BranchDetector(BaseEstimator, ClusterMixin):
 
             self._branch_exemplars[i] = []
             raw_condensed_tree = self._condensed_trees[i]
+            # Group this tree by parent once instead of re-scanning it per leaf
+            # (see hdbscan.prediction._group_by_parent).
+            group_max_lambda, group_rows = _group_by_parent(raw_condensed_tree)
 
             for branch in selected_branches:
                 _branch_exemplars = np.array([], dtype=np.intp)
                 for leaf in recurse_leaf_dfs(branch_cluster_trees[i], np.intp(branch)):
-                    leaf_max_lambda = raw_condensed_tree["lambda_val"][
-                        raw_condensed_tree["parent"] == leaf
-                    ].max()
+                    leaf_rows = group_rows[leaf]
+                    leaf_max_lambda = group_max_lambda[leaf]
                     candidates = raw_condensed_tree["child"][
-                        (raw_condensed_tree["parent"] == leaf)
-                        & (raw_condensed_tree["lambda_val"] == leaf_max_lambda)
+                        leaf_rows[raw_condensed_tree["lambda_val"][leaf_rows]
+                                  == leaf_max_lambda]
                     ]
                     _branch_exemplars = np.hstack([_branch_exemplars, candidates])
                 ids = points[_branch_exemplars]

--- a/hdbscan/flat.py
+++ b/hdbscan/flat.py
@@ -35,7 +35,8 @@ from .hdbscan_ import HDBSCAN, _tree_to_labels
 from .plots import _bfs_from_cluster_tree, _get_leaves
 from .prediction import (PredictionData,
                          _find_cluster_and_probability,
-                         _find_neighbor_and_lambda)
+                         _find_neighbor_and_lambda,
+                         _group_by_parent)
 from ._prediction_utils import (get_tree_row_with_child,
                                 dist_membership_vector,
                                 outlier_membership_vector,
@@ -798,11 +799,13 @@ def re_init(predData, condensed_tree,
     predData.max_lambdas = {}
     predData.exemplars = []
 
+    # Group the raw tree by parent once instead of re-scanning it per
+    # cluster/leaf below (see hdbscan.prediction._group_by_parent).
+    group_max_lambda, group_rows = _group_by_parent(raw_condensed_tree)
+
     for cluster in selected_clusters:
         # max_lambda <=> smallest distance <=> most persistent point(s)
-        predData.max_lambdas[cluster] = \
-                    raw_condensed_tree['lambda_val'][
-                        raw_condensed_tree['parent'] == cluster].max()
+        predData.max_lambdas[cluster] = group_max_lambda[cluster]
 
         # Map all sub-clusters of selected cluster to the selected cluster's
         #       label in output.
@@ -818,12 +821,12 @@ def re_init(predData, condensed_tree,
         #       and leaves of leaves, and so on...
         for leaf in predData._recurse_leaf_dfs(cluster):
             # Largest lambda => Most persistent points
-            leaf_max_lambda = raw_condensed_tree['lambda_val'][
-                raw_condensed_tree['parent'] == leaf].max()
+            leaf_rows = group_rows[leaf]
+            leaf_max_lambda = group_max_lambda[leaf]
             # Get the most persistent points
             points = raw_condensed_tree['child'][
-                (raw_condensed_tree['parent'] == leaf)
-                & (raw_condensed_tree['lambda_val'] == leaf_max_lambda)
+                leaf_rows[raw_condensed_tree['lambda_val'][leaf_rows]
+                          == leaf_max_lambda]
             ]
             # Add most persistent points as exemplars
             cluster_exemplars = np.hstack([cluster_exemplars, points])

--- a/hdbscan/prediction.py
+++ b/hdbscan/prediction.py
@@ -18,6 +18,56 @@ from ._prediction_utils import (get_tree_row_with_child,
 from warnings import warn
 
 
+def _group_by_parent(tree):
+    """Group a raw condensed tree by the ``parent`` field in a single pass.
+
+    The condensed tree stores one row per (parent, child) edge. A lot of the
+    prediction code needs, for a given ``parent`` cluster, the maximum
+    ``lambda_val`` over its rows (and sometimes the rows themselves). The
+    historical idiom did that with a fresh boolean-mask scan of the *whole*
+    tree for every cluster::
+
+        tree['lambda_val'][tree['parent'] == cluster].max()
+
+    which is O(n) per cluster, i.e. O(n * num_clusters) overall (and a clean
+    O(n^2) when looping over every distinct parent). This helper does the
+    grouping once: O(n log n) to sort by parent, then a single grouped reduce.
+
+    Parameters
+    ----------
+    tree : structured ndarray
+        A raw condensed tree with at least ``parent`` and ``lambda_val`` fields.
+
+    Returns
+    -------
+    max_lambda : dict {int parent -> float max lambda_val among its rows}
+
+    row_indices : dict {int parent -> ndarray of row indices with that parent}
+        Indices are in ascending (original-row) order, so downstream selection
+        preserves the same ordering as the old boolean-mask approach.
+    """
+    parents = tree['parent']
+    if len(parents) == 0:
+        return {}, {}
+
+    # Stable sort keeps original row order within each parent group, so the
+    # row_indices arrays match the order a boolean mask would have produced.
+    order = np.argsort(parents, kind='stable')
+    sorted_parents = parents[order]
+    # boundaries[k] = first row of the k-th distinct parent in sorted order.
+    boundaries = np.concatenate((
+        [0],
+        np.flatnonzero(sorted_parents[1:] != sorted_parents[:-1]) + 1,
+    ))
+    keys = sorted_parents[boundaries]
+
+    group_max = np.maximum.reduceat(tree['lambda_val'][order], boundaries)
+    max_lambda = dict(zip(keys, group_max.tolist()))
+    # np.split returns views into `order` (no copy) -> one index array per parent
+    row_indices = dict(zip(keys, np.split(order, boundaries[1:])))
+    return max_lambda, row_indices
+
+
 class PredictionData(object):
     """
     Extra data that allows for faster prediction if cached.
@@ -118,13 +168,15 @@ class PredictionData(object):
         all_clusters = set(np.hstack([self.cluster_tree['parent'],
                                       self.cluster_tree['child']]))
 
+        # Group the raw tree by parent once instead of re-scanning it per
+        # cluster/leaf below (see _group_by_parent).
+        group_max_lambda, group_rows = _group_by_parent(raw_condensed_tree)
+
         for cluster in all_clusters:
-            self.leaf_max_lambdas[cluster] = raw_condensed_tree['lambda_val'][
-                raw_condensed_tree['parent'] == cluster].max()
+            self.leaf_max_lambdas[cluster] = group_max_lambda[cluster]
 
         for cluster in selected_clusters:
-            self.max_lambdas[cluster] = \
-                raw_condensed_tree['lambda_val'][raw_condensed_tree['parent'] == cluster].max()
+            self.max_lambdas[cluster] = group_max_lambda[cluster]
 
             for sub_cluster in self._clusters_below(cluster):
                 self.cluster_map[sub_cluster] = self.cluster_map[cluster]
@@ -132,11 +184,11 @@ class PredictionData(object):
 
             cluster_exemplars = np.array([], dtype=np.int64)
             for leaf in self._recurse_leaf_dfs(cluster):
-                leaf_max_lambda = raw_condensed_tree['lambda_val'][
-                    raw_condensed_tree['parent'] == leaf].max()
+                leaf_rows = group_rows[leaf]
+                leaf_max_lambda = group_max_lambda[leaf]
                 points = raw_condensed_tree['child'][
-                    (raw_condensed_tree['parent'] == leaf)
-                    & (raw_condensed_tree['lambda_val'] == leaf_max_lambda)
+                    leaf_rows[raw_condensed_tree['lambda_val'][leaf_rows]
+                              == leaf_max_lambda]
                 ]
                 cluster_exemplars = np.hstack([cluster_exemplars, points])
 
@@ -495,9 +547,8 @@ def approximate_predict_scores(clusterer, points_to_predict):
     parent_array = tree['parent']
 
     tree_root = parent_array.min()
-    max_lambdas = {}
-    for parent in np.unique(tree['parent']):
-        max_lambdas[parent] = tree[tree['parent'] == parent]['lambda_val'].max()
+    # Grouped max over parents in one pass (was an O(n^2) scan-per-parent loop).
+    max_lambdas, _ = _group_by_parent(tree)
 
     for n in range(tree.shape[0] - 1, -1, -1):
         parent = parent_array[n]


### PR DESCRIPTION
## What

The prediction code repeatedly computed `max(lambda_val)` grouped by `parent` with a fresh boolean-mask scan of the *whole* condensed tree, once per cluster/leaf:

```python
tree['lambda_val'][tree['parent'] == cluster].max()
```

That is O(n) per cluster — O(n·num_clusters) overall, and a clean **O(n²)** in `approximate_predict_scores`'s `for parent in np.unique(tree['parent'])` loop.

This adds `_group_by_parent(tree)` in `prediction.py`: a single **O(n log n)** grouped reduction (stable `argsort` + `np.maximum.reduceat`) returning per-parent max lambda and per-parent row indices. It's reused in four places:

- `PredictionData.__init__`
- `approximate_predict_scores`
- `flat.py`'s prediction-data build
- the branch-exemplar loop in `branches.py`

## Correctness

Behaviour is **bit-identical**, verified with a golden snapshot (old vs new) of `PredictionData` internals, `approximate_predict` labels/probs, `approximate_predict_scores`, `all_points_membership_vectors`, and exemplars. The existing test suite passes (`test_hdbscan`, `test_flat`, `test_branches`, `test_prediction_utils`). A stable sort preserves original row order within each group, so exemplar selection (which picks all children tied at the max lambda) returns the same points in the same order as the boolean-mask version.

## Performance

| points | before | after | speedup |
|---|---|---|---|
| 2,000 | 0.069 ms | 0.043 ms | 1.6× |
| 8,000 | 0.507 ms | 0.171 ms | 3.0× |
| 20,000 | 2.336 ms | 0.465 ms | 5.0× |

Speedup grows with size — the O(n²)→O(n) signature.

## Memory

End-to-end peak RAM is **unchanged**. The only n-sized allocation kept alive is the sort permutation, which stays below each operation's existing high-water mark. Measured `approximate_predict_scores` peak is byte-identical old vs new (2845.7 KB at 20k points), and the build/predict/membership peaks are unchanged within measurement noise.