### PR TITLE
Derive cluster/leaf max-lambdas in PredictionData instead of rescanning

### DIFF
--- a/hdbscan/prediction.py
+++ b/hdbscan/prediction.py
@@ -118,13 +118,16 @@ class PredictionData(object):
         all_clusters = set(np.hstack([self.cluster_tree['parent'],
                                       self.cluster_tree['child']]))
 
+        # Max lambda per parent over the full condensed tree, computed once
+        # with a boolean-mask reduction per group (same peak memory as a
+        # single mask). The selected-cluster and leaf maxes below are the same
+        # quantity, so they are derived from this dict instead of rescanning.
         for cluster in all_clusters:
             self.leaf_max_lambdas[cluster] = raw_condensed_tree['lambda_val'][
                 raw_condensed_tree['parent'] == cluster].max()
 
         for cluster in selected_clusters:
-            self.max_lambdas[cluster] = \
-                raw_condensed_tree['lambda_val'][raw_condensed_tree['parent'] == cluster].max()
+            self.max_lambdas[cluster] = self.leaf_max_lambdas[cluster]
 
             for sub_cluster in self._clusters_below(cluster):
                 self.cluster_map[sub_cluster] = self.cluster_map[cluster]
@@ -132,8 +135,7 @@ class PredictionData(object):
 
             cluster_exemplars = np.array([], dtype=np.int64)
             for leaf in self._recurse_leaf_dfs(cluster):
-                leaf_max_lambda = raw_condensed_tree['lambda_val'][
-                    raw_condensed_tree['parent'] == leaf].max()
+                leaf_max_lambda = self.leaf_max_lambdas[leaf]
                 points = raw_condensed_tree['child'][
                     (raw_condensed_tree['parent'] == leaf)
                     & (raw_condensed_tree['lambda_val'] == leaf_max_lambda)
@@ -494,7 +496,6 @@ def approximate_predict_scores(clusterer, points_to_predict):
 
     parent_array = tree['parent']
 
-    tree_root = parent_array.min()
     max_lambdas = {}
     for parent in np.unique(tree['parent']):
         max_lambdas[parent] = tree[tree['parent'] == parent]['lambda_val'].max()


### PR DESCRIPTION
## What

`PredictionData.__init__` computed the per-parent maximum `lambda_val` over the full condensed tree **three times**, each as a boolean-mask scan per group:

- `leaf_max_lambdas[cluster]` for every cluster in `all_clusters`
- `max_lambdas[cluster]` for every selected cluster — **the same value** as above
- `leaf_max_lambda` per leaf inside the exemplar loop — **also already computed** in `leaf_max_lambdas`

Selected clusters and leaves are subsets of `all_clusters`, so the last two are identical to values already stored in `leaf_max_lambdas`. This computes the quantity **once** and derives the rest via dict lookup, removing the redundant full-tree rescans.

Also drops a dead `tree_root` assignment in `approximate_predict_scores` (unused).

## Why this approach

A single vectorized grouped reduction (`argsort` + `np.maximum.reduceat`) would be asymptotically faster, but it raises peak memory (an O(N) index plus sorted copies) versus the original's reused boolean mask. This change keeps the original mask-reduction loop untouched — **peak memory is unchanged** — and only eliminates the repeated work.

## Results

Measured on synthetic `make_blobs` data (the grouped-max body of `PredictionData.__init__`, isolated from KDTree construction):

| Regime | Speed | Peak RAM |
|---|---|---|
| few clusters (P=39) | 0.90 -> 0.58 ms (**1.5x**) | 48.0 -> 47.5 KB |
| many clusters (P=1191) | 29.9 -> 19.7 ms (**1.5x**) | 145.8 -> 132.9 KB |

- Exact value parity (max of the same multiset).
- `approximate_predict` label agreement with fit labels: 100%.

## Test plan

- [x] `pytest hdbscan/tests/ -k predict` — 9 passed
- [x] `ruff check hdbscan/prediction.py` — clean
- [x] Numerical parity vs the previous implementation on low- and high-cluster-count datasets