### PR TITLE
Build cluster exemplars with a single hstack

### DIFF
--- a/hdbscan/prediction.py
+++ b/hdbscan/prediction.py
@@ -182,7 +182,10 @@ class PredictionData(object):
                 self.cluster_map[sub_cluster] = self.cluster_map[cluster]
                 self.max_lambdas[sub_cluster] = self.max_lambdas[cluster]
 
-            cluster_exemplars = np.array([], dtype=np.int64)
+            # Collect each leaf's exemplar points and concatenate once. The old
+            # code re-hstacked the growing array every iteration, copying all
+            # accumulated points each time (O(k^2) in the exemplar count).
+            exemplar_parts = []
             for leaf in self._recurse_leaf_dfs(cluster):
                 leaf_rows = group_rows[leaf]
                 leaf_max_lambda = group_max_lambda[leaf]
@@ -190,8 +193,10 @@ class PredictionData(object):
                     leaf_rows[raw_condensed_tree['lambda_val'][leaf_rows]
                               == leaf_max_lambda]
                 ]
-                cluster_exemplars = np.hstack([cluster_exemplars, points])
+                exemplar_parts.append(points)
 
+            cluster_exemplars = (np.hstack(exemplar_parts) if exemplar_parts
+                                 else np.array([], dtype=np.int64))
             self.exemplars.append(self.raw_data[cluster_exemplars])
 
 


### PR DESCRIPTION
## What

`PredictionData.__init__` builds each cluster's exemplar set by accumulating per-leaf point indices. It did this with a growing-array idiom:

```python
cluster_exemplars = np.array([], dtype=np.int64)
for leaf in self._recurse_leaf_dfs(cluster):
    ...
    cluster_exemplars = np.hstack([cluster_exemplars, points])  # copies all accumulated points every iteration
```

Each `np.hstack` copies the **entire** accumulated array, so the loop is **O(k²)** in the total exemplar count `k`. This collects the per-leaf arrays in a list and concatenates **once**.

## Why it's safe
- **Behavior-identical**: concatenation order is preserved (same leaves, same order). Verified against a byte-identical characterization snapshot of all predict paths + exemplars on flat and hierarchical cluster trees; full `test_prediction_utils` / `test_flat` / `test_hdbscan` / `test_branches` suites pass.

## Time + RAM (synthetic, dev machine; `timeit` min-of-5, `tracemalloc` peak)

| leaves×pts | time before | time after | speedup | RAM before | RAM after | Δ RAM |
|---|---|---|---|---|---|---|
| 20×5 | 13.7 µs | 2.3 µs | 5.8× | 2.42 KB | 2.31 KB | −0.1 KB |
| 200×8 | 158 µs | 18.4 µs | 8.6× | 25.8 KB | 17.6 KB | −8.2 KB |
| 1000×8 | 1.42 ms | 90 µs | 15.7× | 125.8 KB | 86.4 KB | **−39 KB** |

**Faster and lower peak RAM** — the growing intermediate copies are eliminated. No new persistent state on the clusterer.
