### PR TITLE
Speed up get_finite_row_indices on sparse input

### DIFF
--- a/hdbscan/hdbscan_.py
+++ b/hdbscan/hdbscan_.py
@@ -496,9 +496,15 @@ def is_finite(matrix):
 def get_finite_row_indices(matrix):
     """Returns the indices of the purely finite rows of a sparse matrix or dense ndarray"""
     if issparse(matrix):
-        row_indices = np.array(
-            [i for i, row in enumerate(matrix.tolil().data) if np.all(np.isfinite(row))]
-        )
+        m = matrix.tocsr()
+        # Per-row finite count via a cumulative sum indexed by indptr: avoids
+        # materializing a full LIL copy (lower peak RAM) and the pure-Python
+        # per-row scan. A row is finite iff all its stored elements are finite
+        # (structural zeros are finite), matching the original semantics.
+        csum = np.concatenate([[0], np.cumsum(np.isfinite(m.data))])
+        row_lengths = np.diff(m.indptr)
+        finite_counts = csum[m.indptr[1:]] - csum[m.indptr[:-1]]
+        row_indices = np.where(finite_counts == row_lengths)[0]
     else:
         row_indices = np.where(np.isfinite(matrix).sum(axis=1) == matrix.shape[1])[0]
     return row_indices


### PR DESCRIPTION
## What

`get_finite_row_indices` is used during `fit` to drop rows containing non-finite values before clustering. On sparse input it currently materializes a full LIL copy and scans every row in pure Python:

```python
row_indices = np.array(
    [i for i, row in enumerate(matrix.tolil().data) if np.all(np.isfinite(row))]
)
```

This replaces it with a CSR cumulative-sum reduction (no LIL copy, no Python loop):

```python
m = matrix.tocsr()
csum = np.concatenate([[0], np.cumsum(np.isfinite(m.data))])
row_lengths = np.diff(m.indptr)
finite_counts = csum[m.indptr[1:]] - csum[m.indptr[:-1]]
row_indices = np.where(finite_counts == row_lengths)[0]
```

A row is finite iff all of its stored elements are finite (structural zeros are finite), which matches the original semantics exactly.

## Why

The old path builds an entire LIL representation purely to iterate rows, then runs an interpreted per-row `np.all(np.isfinite(...))`. Both the copy and the loop are avoidable.

## Numbers

Benchmark on a 5000×5000 CSR matrix at 1% density (~2% non-finite entries):

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Time | 17.7 ms | 0.46 ms | −97% |
| Peak RAM | 17.8 MB | 4.2 MB | −77% |

Both time and peak memory go **down**.

## Correctness

Output verified `np.array_equal` to the previous implementation across:
- Hand-built edge cases: empty matrix, leading/trailing empty rows, explicit stored zeros, NaN vs inf, single-element rows.
- 500 randomized fuzz cases (varied shapes, densities, and injected inf/-inf/nan).

The dense branch is unchanged. Full test suite passes (71 passed, 14 skipped).

> Note: a `np.add.reduceat` variant is marginally faster but raises `IndexError` on matrices with trailing empty rows (indptr points past the end of `data`); the cumulative-sum form avoids that while still reducing memory.