### PR TITLE
feat: add Linux arm64 (aarch64) wheel builds

### DIFF
--- a/.github/workflows/pythonpublish_wheel.yml
+++ b/.github/workflows/pythonpublish_wheel.yml
@@ -40,6 +40,36 @@ jobs:
           pipx install twine
           twine upload dist/*.tar.gz --skip-existing
           twine upload wheelhouse/*.whl --skip-existing
+  linux-aarch64-deploy:
+    runs-on: ubuntu-24.04-arm
+    container: quay.io/pypa/manylinux_2_28_aarch64
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - "cp310-cp310"
+          - "cp311-cp311"
+          - "cp312-cp312"
+          - "cp313-cp313"
+          - "cp314-cp314"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+      - name: Build wheel
+        env:
+          PYTHON: /opt/python/${{ matrix.python }}/bin/python
+        run: |
+          $PYTHON -m pip install --upgrade setuptools wheel build "cython>=3.0.11,<4" "numpy>=2.0"
+          $PYTHON -m build --no-isolation
+          auditwheel repair dist/*linux_aarch64.whl
+      - name: Publish to pypi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pipx install twine
+          twine upload wheelhouse/*.whl --skip-existing
   other-deploy:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds a `linux-aarch64-deploy` job to the wheel publish workflow, mirroring the existing `linux-deploy` job for x86_64.

**Approach:** uses GitHub's native `ubuntu-24.04-arm` runner with the `quay.io/pypa/manylinux_2_28_aarch64` container — no QEMU emulation, so builds are fast and reliable. Same Python version matrix as the x86_64 job (3.10–3.14).

**Why this matters:** without aarch64 wheels, installing hdbscan on Linux ARM64 (AWS Graviton, Docker arm64 builds, Apple Silicon CI) requires compiling from source, which needs Python dev headers and adds significant build time. Pre-built wheels eliminate that friction.