### PR TITLE
Speed up UnionFind.fast_find with cached C pointer and full path compression

### DIFF
--- a/hdbscan/_hdbscan_linkage.pyx
+++ b/hdbscan/_hdbscan_linkage.pyx
@@ -211,13 +211,17 @@ cdef class UnionFind (object):
         return
 
     cdef np.intp_t fast_find(self, np.intp_t n):
-        cdef np.intp_t p
+        cdef np.intp_t p, tmp
         p = n
-        while self.parent_arr[n] != -1:
-            n = self.parent_arr[n]
-        # label up to the root
-        while self.parent_arr[p] != n:
-            p, self.parent_arr[p] = self.parent_arr[p], n
+        # walk to the root using the cached C pointer (parent_arr is untyped,
+        # so indexing it goes through boxed Python getitem/setitem)
+        while self.parent[n] != -1:
+            n = self.parent[n]
+        # full path compression: point every node on the path at the root
+        while self.parent[p] != -1:
+            tmp = self.parent[p]
+            self.parent[p] = n
+            p = tmp
         return n
 
 
@@ -243,10 +247,10 @@ cpdef np.ndarray[np.double_t, ndim=2] label(np.ndarray[np.double_t, ndim=2] L):
 
         aa, bb = U.fast_find(a), U.fast_find(b)
 
-        result[index][0] = aa
-        result[index][1] = bb
-        result[index][2] = delta
-        result[index][3] = U.size[aa] + U.size[bb]
+        result[index, 0] = aa
+        result[index, 1] = bb
+        result[index, 2] = delta
+        result[index, 3] = U.size[aa] + U.size[bb]
 
         U.union(aa, bb)
 


### PR DESCRIPTION
## What this changes

`UnionFind.fast_find` runs twice per edge inside `label()`, the function that turns the single-linkage MST into the labelled hierarchy. It sits on every `fit()` path, no matter the algorithm or metric.

Two things made it slow:

1. `parent_arr` is declared as a bare `cdef np.ndarray` with no element type, so every `self.parent_arr[n]` read and write went through Python's boxed `__getitem__` / `__setitem__` instead of a plain C array access. The class already keeps a typed C pointer to the same buffer (`self.parent`, an `np.intp_t *`) and uses it in `union()`, but `fast_find` never touched it.
2. The compression loop only relabelled a single node per call. As the union-find forest grows, find paths get longer and that Python-speed walk gets more expensive.

The fix uses the pointer that was already there, and compresses the whole path to the root on each call:

```cython
cdef np.intp_t fast_find(self, np.intp_t n):
    cdef np.intp_t p, tmp
    p = n
    # walk to the root using the cached C pointer (parent_arr is untyped,
    # so indexing it goes through boxed Python getitem/setitem)
    while self.parent[n] != -1:
        n = self.parent[n]
    # full path compression: point every node on the path at the root
    while self.parent[p] != -1:
        tmp = self.parent[p]
        self.parent[p] = n
        p = tmp
    return n
```

I also changed the result writes in `label()` from `result[index][0]` to `result[index, 0]`. The first form builds a throwaway 1-D memoryview per row before indexing it; the comma form indexes the 2-D view directly.

`parent_arr` stays as the owning array (it backs the pointer), so nothing dangles.

## Correctness

The returned root is the same as before; only the union-find internals change. The old code had one quirk worth calling out: when `fast_find` was handed a node that was already a root, the second loop ran once with `p` wrapping to `-1` and wrote into `parent_arr[-1]`, the last slot. That write was harmless, because that slot holds the final merge label and is never read before the function returns. The new version skips it, and the output is identical either way.

I checked byte-for-byte equality against the current compiled module on:

- random MSTs (8 seeds x 5 sizes, 2 to 500 points)
- deep linear-chain MSTs (the worst case for find-path length)
- end-to-end fits on all six algorithms, plus degenerate inputs (5 points, heavy duplicates)

Everything came back `np.array_equal`. The existing test suite passes (34 passed, 4 skipped).

## Benchmark

`label()` timed on real Boruvka MSTs (`make_blobs`, 10 centers, 2-D), plus adversarial chains. Speed is the `timeit` min; peak RAM is the `tracemalloc` peak around one call, measured separately with a reset between runs. Both the old and new `fast_find` were compiled into a single module with the repo's Cython directives.

| case | N | old time | new time | speedup | old peak | new peak | Δ RAM | match |
|------|--:|---------:|---------:|--------:|---------:|---------:|------:|:-----:|
| blobs | 10,000 | 13.83 ms | 0.18 ms | 77.6x | 1017.7 KB | 1017.7 KB | +0.00% | OK |
| blobs | 50,000 | 96.95 ms | 1.27 ms | 76.6x | 4.96 MB | 4.96 MB | +0.00% | OK |
| blobs | 200,000 | 568.82 ms | 6.28 ms | 90.6x | 19.84 MB | 19.84 MB | +0.00% | OK |
| blobs | 500,000 | 2.052 s | 17.71 ms | 115.9x | 49.59 MB | 49.59 MB | +0.00% | OK |
| blobs | 1,000,000 | 5.113 s | 46.15 ms | 110.8x | 99.18 MB | 99.18 MB | +0.00% | OK |
| chain | 20,000 | 8.88 ms | 0.15 ms | 57.8x | 1.99 MB | 1.99 MB | +0.00% | OK |
| chain | 100,000 | 40.97 ms | 0.70 ms | 58.7x | 9.92 MB | 9.92 MB | +0.00% | OK |

Speed grows with N because the old partial compression let paths get longer; at 1M points it goes from 5.1 s to 46 ms. Peak RAM is identical to the byte at every size, since both versions allocate the same three arrays (`result_arr`, `parent_arr`, `size_arr`). The change is purely about time.

These are dev-machine numbers (macOS arm64, Python 3.14, numpy 2.x), so read them as relative, not absolute.

<details>
<summary>Benchmark script (compiles both versions side by side)</summary>

`ub.pyx` carries the old and new `fast_find` in one module so they share a compile and run back to back on the same machine state:

```cython
# distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
# cython: boundscheck=False
# cython: nonecheck=False
import numpy as np
cimport numpy as np

cdef class UnionFind(object):
    cdef np.ndarray parent_arr
    cdef np.ndarray size_arr
    cdef np.intp_t next_label
    cdef np.intp_t *parent
    cdef np.intp_t *size

    def __init__(self, N):
        self.parent_arr = -1 * np.ones(2 * N - 1, dtype=np.intp, order='C')
        self.next_label = N
        self.size_arr = np.hstack((np.ones(N, dtype=np.intp),
                                   np.zeros(N - 1, dtype=np.intp)))
        self.parent = (<np.intp_t *> self.parent_arr.data)
        self.size = (<np.intp_t *> self.size_arr.data)

    cdef void union(self, np.intp_t m, np.intp_t n):
        self.size[self.next_label] = self.size[m] + self.size[n]
        self.parent[m] = self.next_label
        self.parent[n] = self.next_label
        self.next_label += 1

    # OLD: untyped parent_arr getitem/setitem + partial compression
    cdef np.intp_t fast_find_old(self, np.intp_t n):
        cdef np.intp_t p
        p = n
        while self.parent_arr[n] != -1:
            n = self.parent_arr[n]
        while self.parent_arr[p] != n:
            p, self.parent_arr[p] = self.parent_arr[p], n
        return n

    # NEW: cached C pointer + full path compression
    cdef np.intp_t fast_find_new(self, np.intp_t n):
        cdef np.intp_t p, tmp
        p = n
        while self.parent[n] != -1:
            n = self.parent[n]
        while self.parent[p] != -1:
            tmp = self.parent[p]
            self.parent[p] = n
            p = tmp
        return n


cpdef np.ndarray[np.double_t, ndim=2] label_old(np.ndarray[np.double_t, ndim=2] L):
    cdef np.ndarray[np.double_t, ndim=2] result_arr
    cdef np.double_t[:, ::1] result
    cdef np.intp_t N, a, b, aa, bb, index
    cdef np.double_t delta
    result_arr = np.zeros((L.shape[0], L.shape[1] + 1))
    result = (<np.double_t[:L.shape[0], :4:1]> (<np.double_t *> result_arr.data))
    N = L.shape[0] + 1
    U = UnionFind(N)
    for index in range(L.shape[0]):
        a = <np.intp_t> L[index, 0]
        b = <np.intp_t> L[index, 1]
        delta = L[index, 2]
        aa, bb = U.fast_find_old(a), U.fast_find_old(b)
        result[index][0] = aa
        result[index][1] = bb
        result[index][2] = delta
        result[index][3] = U.size[aa] + U.size[bb]
        U.union(aa, bb)
    return result_arr


cpdef np.ndarray[np.double_t, ndim=2] label_new(np.ndarray[np.double_t, ndim=2] L):
    cdef np.ndarray[np.double_t, ndim=2] result_arr
    cdef np.double_t[:, ::1] result
    cdef np.intp_t N, a, b, aa, bb, index
    cdef np.double_t delta
    result_arr = np.zeros((L.shape[0], L.shape[1] + 1))
    result = (<np.double_t[:L.shape[0], :4:1]> (<np.double_t *> result_arr.data))
    N = L.shape[0] + 1
    U = UnionFind(N)
    for index in range(L.shape[0]):
        a = <np.intp_t> L[index, 0]
        b = <np.intp_t> L[index, 1]
        delta = L[index, 2]
        aa, bb = U.fast_find_new(a), U.fast_find_new(b)
        result[index, 0] = aa
        result[index, 1] = bb
        result[index, 2] = delta
        result[index, 3] = U.size[aa] + U.size[bb]
        U.union(aa, bb)
    return result_arr
```

`setup.py`:

```python
from setuptools import Extension, setup
from Cython.Build import cythonize
import numpy as np
setup(ext_modules=cythonize([Extension("ub", ["ub.pyx"],
      include_dirs=[np.get_include()])], language_level=3))
# build: python setup.py build_ext --inplace
```

`run.py`:

```python
import gc, timeit, tracemalloc
import numpy as np
from sklearn.datasets import make_blobs
from sklearn.neighbors import KDTree
from hdbscan._hdbscan_boruvka import KDTreeBoruvkaAlgorithm
import ub

def boruvka_mst(n, seed=1):
    X, _ = make_blobs(n_samples=n, centers=10, n_features=2, random_state=seed)
    alg = KDTreeBoruvkaAlgorithm(KDTree(X), min_samples=4, metric='euclidean', leaf_size=14)
    mst = alg.spanning_tree()
    return mst[np.argsort(mst[:, 2]), :].copy()

def chain_mst(n):  # linear chain -> long find paths for the old code
    L = np.empty((n - 1, 3))
    L[:, 0] = np.arange(n - 1); L[:, 1] = np.arange(1, n); L[:, 2] = np.arange(1, n, dtype=float)
    return L

def peak_ram(fn, L):
    gc.collect(); gc.disable()
    tracemalloc.start()
    fn(L.copy())
    peak = tracemalloc.get_traced_memory()[1]
    tracemalloc.stop(); gc.enable()
    return peak

def speed(fn, L, reps):
    return min(timeit.repeat(lambda: fn(L.copy()), number=1, repeat=reps))

cases = [("blobs", n, boruvka_mst(n)) for n in (10_000, 50_000, 200_000, 500_000, 1_000_000)]
cases += [("chain", n, chain_mst(n)) for n in (20_000, 100_000)]

for name, n, L in cases:
    assert np.array_equal(ub.label_old(L.copy()), ub.label_new(L.copy()))
    reps_old = 3 if (n >= 500_000 or name == "chain") else 7
    to, tn = speed(ub.label_old, L, reps_old), speed(ub.label_new, L, 10)
    mo, mn = peak_ram(ub.label_old, L), peak_ram(ub.label_new, L)
    print(f"{name:<7}{n:>9} | {to*1e3:9.2f}ms {tn*1e3:8.2f}ms {to/tn:6.1f}x | "
          f"{mo/1024**2:7.2f}MB {mn/1024**2:7.2f}MB {(mn-mo)/mo*100:+.2f}%")
```
</details>

The MST construction itself is untouched, so this is a constant-factor win on the labelling step, not a change to any algorithm.
