### PR TITLE
Fix numerical overflow in all_points_core_distance / validity_index (#665)

### DIFF
--- a/hdbscan/tests/test_hdbscan.py
+++ b/hdbscan/tests/test_hdbscan.py
@@ -197,6 +197,55 @@ def test_hdbscan_feature_vector():
     assert validity >= 0.4
 
 
+def test_validity_index_overflow():
+    """Regression test for issue #665.
+
+    ``all_points_core_distance`` used to evaluate ``(1 / dist) ** d``
+    directly, which overflows float64 for small pairwise distances and/or
+    high dimension ``d``. The overflow raised a ``RuntimeWarning`` and
+    silently corrupted the core distances (they collapsed to 0), corrupting
+    ``validity_index``. It is now computed in log-space.
+    """
+    from hdbscan.validity import all_points_core_distance
+
+    # (a) High-dimensional data with small within-cluster distances used to
+    # overflow: validity_index must now be finite with no overflow warning.
+    rng = np.random.RandomState(0)
+    dim = 200
+    cluster0 = rng.normal(0.0, 5e-4, size=(25, dim))
+    cluster1 = rng.normal(0.0, 5e-4, size=(25, dim))
+    cluster1[:, 0] += 10.0  # separate the two clusters
+    X_highdim = np.vstack([cluster0, cluster1])
+    labels_highdim = np.array([0] * 25 + [1] * 25)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        validity = validity_index(X_highdim, labels_highdim)
+    overflow_warnings = [
+        w for w in caught
+        if issubclass(w.category, RuntimeWarning) and "overflow" in str(w.message)
+    ]
+    assert not overflow_warnings, "overflow warning raised (issue #665)"
+    assert np.isfinite(validity)
+
+    # (b) On a non-overflowing distance matrix the result must stay
+    # numerically equal to the original ``(mean of (1/dist)**d)**(-1/d)``.
+    dist = np.array([
+        [0.0, 0.4, 0.8, 0.5],
+        [0.4, 0.0, 0.3, 0.9],
+        [0.8, 0.3, 0.0, 0.6],
+        [0.5, 0.9, 0.6, 0.0],
+    ])
+    d = 5.0
+    reference = dist.copy()
+    reference[reference != 0] = (1.0 / reference[reference != 0]) ** d
+    reference = reference.sum(axis=1) / (reference.shape[0] - 1)
+    reference **= (-1.0 / d)
+    assert_array_almost_equal(
+        all_points_core_distance(dist.copy(), d=d), reference, decimal=9
+    )
+
+
 def test_hdbscan_prims_kdtree():
     labels, p, persist, ctree, ltree, mtree = hdbscan(X, algorithm="prims_kdtree")
     n_clusters_1 = len(set(labels)) - int(-1 in labels)

--- a/hdbscan/validity.py
+++ b/hdbscan/validity.py
@@ -1,6 +1,7 @@
 import numpy as np
 from sklearn.metrics import pairwise_distances
 from scipy.spatial.distance import cdist
+from scipy.special import logsumexp
 from ._hdbscan_linkage import mst_linkage_core
 from numpy import isclose
 
@@ -27,15 +28,24 @@ def all_points_core_distance(distance_matrix, d=2.0):
     Moulavi, D., Jaskowiak, P.A., Campello, R.J., Zimek, A. and Sander, J.,
     2014. Density-Based Clustering Validation. In SDM (pp. 839-847).
     """
-    distance_matrix[distance_matrix != 0] = (1.0 / distance_matrix[
-        distance_matrix != 0]) ** d
-    result = distance_matrix.sum(axis=1)
-    result /= distance_matrix.shape[0] - 1
+    # The all-points-core-distance of a point i is
+    #     ( mean_{j != i, dist_ij != 0} (1 / dist_ij) ** d ) ** (-1 / d).
+    # Computing (1 / dist) ** d directly overflows float64 for small distances
+    # and/or high dimension d, corrupting the result (see issue #665). Since
+    # log((1 / dist) ** d) = -d * log(dist), the mean is evaluated in log-space
+    # with logsumexp so the huge (1 / dist) ** d term is never materialized.
+    # Zero distances are excluded exactly as before by giving them a log-term of
+    # -inf, which contributes 0 to the sum.
+    nonzero = distance_matrix != 0
+    log_terms = np.full(distance_matrix.shape, -np.inf, dtype=np.float64)
+    log_terms[nonzero] = -d * np.log(distance_matrix[nonzero])
 
-    if result.sum() == 0:
+    log_result = logsumexp(log_terms, axis=1) - np.log(distance_matrix.shape[0] - 1)
+
+    if np.all(np.isneginf(log_result)):
         result = np.zeros(len(distance_matrix))
     else:
-        result **= (-1.0 / d)
+        result = np.exp((-1.0 / d) * log_result)
 
     return result
 


### PR DESCRIPTION
Fixes #665. (The same overflow was flagged earlier in #197.)

## Why

`hdbscan/validity.py::all_points_core_distance` computes each point's
all-points-core-distance as

```
apcd_i = ( mean_{j != i, dist_ij != 0} (1 / dist_ij) ** d ) ** (-1 / d)
```

where `d` is the data dimensionality (`X.shape[1]`). The old code materialized
`(1 / dist_ij) ** d` directly:

```python
distance_matrix[distance_matrix != 0] = (1.0 / distance_matrix[distance_matrix != 0]) ** d
```

For small mutual-reachability distances and/or high dimension `d`, `(1/dist)**d`
exceeds the float64 range (~1.8e308) and overflows to `inf`. This:

1. emits `RuntimeWarning: overflow encountered in power`, and
2. **silently corrupts the result**: the overflowed `inf` mean becomes
   `inf ** (-1/d) = 0`, so the core distance collapses to `0` instead of the true
   (small) value. That wrong `0` then flows into the mutual-reachability distances,
   density sparseness, and finally `validity_index`, producing a corrupted score
   with no error.

### Reproduction (current `master`)

```python
import numpy as np
from hdbscan.validity import all_points_core_distance

dm = np.array([[0.,1e-3,2e-3],[1e-3,0.,1.5e-3],[2e-3,1.5e-3,0.]])
all_points_core_distance(dm.copy(), d=200)
# RuntimeWarning: overflow encountered in power
# -> array([0., 0., 0.])          # WRONG: correct values are ~[1e-3, 1e-3, 1.5e-3]
```

Full `validity_index` on high-dimensional data with small within-cluster distances
(D=200, spread ~1e-2) raises the overflow warning and returns a corrupted value;
under `np.errstate(over="raise")` it raises `FloatingPointError`.

## What

Evaluate the inner mean in **log-space** so the huge `(1/dist)**d` term is never
materialized. Using `log((1/dist)**d) = -d * log(dist)` and
`scipy.special.logsumexp`:

```
apcd_i = ( S_i / (n-1) ) ** (-1/d)
       = exp( (-1/d) * ( logsumexp_j(-d*log dist_ij) - log(n-1) ) )
```

The only difference from the original is *where* the exponentiation happens: we
apply `(-1/d)` to the log of the sum, so the intermediate never grows beyond `exp`
range (and `logsumexp` internally subtracts the per-row max, so `exp(·) ∈ (0,1]`).
Zero distances (diagonal + coincident points) are excluded exactly as before by
giving them a log-term of `-inf` (contributing 0 to the sum). The
`result.sum() == 0` guard (all distances zero) is preserved as
`np.all(np.isneginf(log_result))`.

```python
nonzero = distance_matrix != 0
log_terms = np.full(distance_matrix.shape, -np.inf, dtype=np.float64)
log_terms[nonzero] = -d * np.log(distance_matrix[nonzero])
log_result = logsumexp(log_terms, axis=1) - np.log(distance_matrix.shape[0] - 1)
if np.all(np.isneginf(log_result)):
    result = np.zeros(len(distance_matrix))
else:
    result = np.exp((-1.0 / d) * log_result)
```

(The new version no longer mutates its input `distance_matrix`; the sole caller
already passes a `.copy()`, so this is safe and slightly cleaner.)

## Numerical equivalence (the important part)

The rewrite is mathematically identical to the original on inputs that don't
overflow, and only *changes behavior where the original was already wrong* (overflow
→ now finite/correct instead of `0`).

- **2000 random non-overflowing distance matrices** (n∈[2,11], d∈{2,3,5,8,13,20},
  scale∈{0.5,1,3,10}), old vs new: **max relative difference 8.2e-16** (machine ε).
- **Full `validity_index`, old vs new** over 30 `make_blobs` datasets (2/5/10-D):
  **max relative difference 1.3e-15**.
- **Edge cases match exactly**: all-zero → zeros; coincident pair (off-diagonal zero
  excluded from the sum but still counted in the `n-1` divisor) → identical;
  single-point cluster → `nan` in both.
- **Overflow case now fixed**: the reproduction returns finite, correct core
  distances with no warning.

## Tests

Added `test_validity_index_overflow` in `hdbscan/tests/test_hdbscan.py`:
(a) high-dimensional / small-distance dataset — asserts `validity_index` is finite
and raises **no** overflow `RuntimeWarning` (fails on `master`); (b) on a fixed
non-overflowing matrix, asserts `all_points_core_distance` equals the original
`(mean of (1/dist)**d)**(-1/d)` formula (computed inline) to 9 decimals.
`pytest hdbscan/tests/test_hdbscan.py`: **33 passed, 6 skipped**.

## Notes for reviewers

- Adds `scipy.special.logsumexp` — SciPy is already a hard dependency; `logsumexp`
  is available in all supported versions.
- Values on non-overflowing data change only at ~1e-15 (float re-association), so
  existing `validity_index` numbers are unaffected in practice.
- Behavior legitimately *changes* only where the old code overflowed (silent `0` →
  correct small positive value).
- Alternatives a maintainer might prefer: higher-precision core-distance computation,
  or clip/warn on overflow. Log-space was chosen as exact, allocation-light, and is
  what both #665 and #197 suggested.
